### PR TITLE
fix(issue-2): Add bind packet support for explicit session-aware flow…

### DIFF
--- a/include/knock_crypto.h
+++ b/include/knock_crypto.h
@@ -10,6 +10,8 @@ struct knock_sig_input {
     __u32 session_id_hi;
     __u32 session_id_lo;
     __u32 nonce;
+    __u16 bind_src_port;
+    __u16 bind_dst_port;
 };
 
 static __inline __u64 knock_rotl64(__u64 x, __u8 b)
@@ -89,9 +91,12 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
                ((in->session_id_hi >> 8) & 0x00ffffffU);
     __u64 m2 = ((__u64)(in->session_id_hi & 0x000000ffU) << 56) |
                ((__u64)in->session_id_lo << 24) |
+               ((__u64)in->bind_src_port << 8) |
+               (__u64)(in->bind_dst_port >> 8);
+    __u64 m3 = ((__u64)(in->bind_dst_port & 0x00ffU) << 56) |
                0x0053474e31ULL;
     __u64 h0 = knock_siphash24_16b(k0 ^ k2, k1 ^ k3, m0, m1, 0x0101010101010101ULL);
-    __u64 h1 = knock_siphash24_16b(k0 ^ ~k2, k1 ^ ~k3, m2, m0, 0x0202020202020202ULL);
+    __u64 h1 = knock_siphash24_16b(k0 ^ ~k2, k1 ^ ~k3, m2, m3, 0x0202020202020202ULL);
 
     out[0] = (__u32)(h0 >> 32);
     out[1] = (__u32)(h0 & 0xffffffffU);

--- a/include/shared.h
+++ b/include/shared.h
@@ -19,6 +19,7 @@
 
 #define KNOCK_PKT_AUTH 1U
 #define KNOCK_PKT_DEAUTH 2U
+#define KNOCK_PKT_BIND 3U
 
 #define KNOCK_USER_ID_SHIFT 16U
 #define KNOCK_USER_ID_MASK 0xffff0000U
@@ -31,6 +32,9 @@ struct knock_packet {
     __u8 reserved[3];
     __u32 session_id_hi;
     __u32 session_id_lo;
+    __u16 bind_src_port;
+    __u16 bind_dst_port;
+    __u32 bind_reserved;
     __u32 signature[KNOCK_SIGNATURE_WORDS];
 } __attribute__((packed));
 

--- a/src/bpf/knock_kern.bpf.c
+++ b/src/bpf/knock_kern.bpf.c
@@ -17,7 +17,7 @@ struct {
 struct {
     __uint(type, BPF_MAP_TYPE_HASH);
     __uint(max_entries, 4096);
-    __type(key, __u32);
+    __type(key, struct session_lookup_key);
     __type(value, struct pending_auth_state);
 } pending_auth_map SEC(".maps");
 
@@ -117,6 +117,8 @@ static __always_inline bool knock_is_valid_with_key(const __u8 key[KNOCK_HMAC_KE
     __u8 packet_type = pkt->packet_type;
     __u32 session_id_hi = bpf_ntohl(pkt->session_id_hi);
     __u32 session_id_lo = bpf_ntohl(pkt->session_id_lo);
+    __u16 bind_src_port = bpf_ntohs(pkt->bind_src_port);
+    __u16 bind_dst_port = bpf_ntohs(pkt->bind_dst_port);
     struct knock_sig_input in = {};
     __u32 sig[KNOCK_SIGNATURE_WORDS];
     __u32 i;
@@ -125,7 +127,7 @@ static __always_inline bool knock_is_valid_with_key(const __u8 key[KNOCK_HMAC_KE
         return false;
     }
 
-    if (packet_type != KNOCK_PKT_AUTH && packet_type != KNOCK_PKT_DEAUTH) {
+    if (packet_type != KNOCK_PKT_AUTH && packet_type != KNOCK_PKT_DEAUTH && packet_type != KNOCK_PKT_BIND) {
         return false;
     }
 
@@ -141,6 +143,8 @@ static __always_inline bool knock_is_valid_with_key(const __u8 key[KNOCK_HMAC_KE
     in.session_id_hi = session_id_hi;
     in.session_id_lo = session_id_lo;
     in.nonce = nonce;
+    in.bind_src_port = bind_src_port;
+    in.bind_dst_port = bind_dst_port;
 
     knock_signature_words(key, &in, sig);
 #pragma clang loop unroll(full)
@@ -172,6 +176,7 @@ int port_knock_xdp(struct xdp_md *ctx)
     struct pending_auth_state new_pending = {};
     struct active_session_state new_sess = {};
     struct session_lookup_key lookup_key = {};
+    struct session_lookup_key pending_key = {};
     struct flow_key flow = {};
     struct flow_key *bound_flow;
     struct knock_config *cfg;
@@ -237,6 +242,8 @@ int port_knock_xdp(struct xdp_md *ctx)
         __u32 session_id_hi;
         __u32 session_id_lo;
         __u8 packet_type;
+        __u16 bind_src_port;
+        __u16 bind_dst_port;
         __u64 replay_window_ns;
         struct replay_nonce_key replay_key = {};
         struct replay_nonce_state replay_state = {};
@@ -254,6 +261,8 @@ int port_knock_xdp(struct xdp_md *ctx)
         packet_type = kpkt->packet_type;
         session_id_hi = bpf_ntohl(kpkt->session_id_hi);
         session_id_lo = bpf_ntohl(kpkt->session_id_lo);
+        bind_src_port = bpf_ntohs(kpkt->bind_src_port);
+        bind_dst_port = bpf_ntohs(kpkt->bind_dst_port);
 
         if (snap) {
             snap->magic = kpkt->magic;
@@ -292,6 +301,10 @@ int port_knock_xdp(struct xdp_md *ctx)
                 return XDP_DROP;
             }
 
+            pending_key.src_ip = iph->saddr;
+            pending_key.session_id_hi = session_id_hi;
+            pending_key.session_id_lo = session_id_lo;
+
             replay_key.src_ip = iph->saddr;
             replay_key.nonce = nonce_host;
             replay_key.packet_type = packet_type;
@@ -323,12 +336,39 @@ int port_knock_xdp(struct xdp_md *ctx)
                 new_pending.session_id_hi = session_id_hi;
                 new_pending.session_id_lo = session_id_lo;
                 new_pending.expires_at_ns = now_ns + ((__u64)cfg->bind_window_ms * 1000000ULL);
-                if (!update_map_or_fail(stats ? &stats->map_update_fail : NULL,
-                                        &pending_auth_map,
-                                        &iph->saddr,
-                                        &new_pending)) {
+                bpf_map_update_elem(&pending_auth_map, &pending_key, &new_pending, BPF_ANY);
+                bump(stats ? &stats->knock_valid : NULL);
+            } else if (packet_type == KNOCK_PKT_BIND) {
+                pending = bpf_map_lookup_elem(&pending_auth_map, &pending_key);
+                if (!pending) {
+                    bump(stats ? &stats->bind_drop : NULL);
                     return XDP_DROP;
                 }
+                if (pending->expires_at_ns < now_ns) {
+                    bpf_map_delete_elem(&pending_auth_map, &pending_key);
+                    bump(stats ? &stats->bind_drop : NULL);
+                    return XDP_DROP;
+                }
+                if (bind_src_port != src_port || bind_dst_port == 0 || !is_protected_port(cfg, bind_dst_port)) {
+                    bump(stats ? &stats->bind_drop : NULL);
+                    return XDP_DROP;
+                }
+
+                flow.src_port = bind_src_port;
+                flow.dst_port = bind_dst_port;
+                new_sess.session_id_hi = session_id_hi;
+                new_sess.session_id_lo = session_id_lo;
+                new_sess.expires_at_ns = now_ns + ((__u64)cfg->timeout_ms * 1000000ULL);
+                bpf_map_update_elem(&active_session_map, &flow, &new_sess, 0);
+
+                lookup_key.src_ip = iph->saddr;
+                lookup_key.session_id_hi = session_id_hi;
+                lookup_key.session_id_lo = session_id_lo;
+                if (bpf_map_update_elem(&session_index_map, &lookup_key, &flow, 0) != 0) {
+                    bpf_map_delete_elem(&active_session_map, &flow);
+                    return XDP_DROP;
+                }
+                bpf_map_delete_elem(&pending_auth_map, &pending_key);
                 bump(stats ? &stats->knock_valid : NULL);
             } else {
                 deauth_key.src_ip = iph->saddr;
@@ -355,42 +395,8 @@ int port_knock_xdp(struct xdp_md *ctx)
 
     sess = bpf_map_lookup_elem(&active_session_map, &flow);
     if (!sess) {
-        pending = bpf_map_lookup_elem(&pending_auth_map, &iph->saddr);
-        if (!pending) {
-            bump(stats ? &stats->protected_drop : NULL);
-            return XDP_DROP;
-        }
-        if (pending->expires_at_ns < now_ns) {
-            bpf_map_delete_elem(&pending_auth_map, &iph->saddr);
-            bump(stats ? &stats->bind_drop : NULL);
-            bump(stats ? &stats->protected_drop : NULL);
-            return XDP_DROP;
-        }
-
-        new_sess.session_id_hi = pending->session_id_hi;
-        new_sess.session_id_lo = pending->session_id_lo;
-        new_sess.expires_at_ns = now_ns + ((__u64)cfg->timeout_ms * 1000000ULL);
-        if (!update_map_or_fail(stats ? &stats->map_update_fail : NULL,
-                                &active_session_map,
-                                &flow,
-                                &new_sess)) {
-            return XDP_DROP;
-        }
-
-        lookup_key.src_ip = iph->saddr;
-        lookup_key.session_id_hi = pending->session_id_hi;
-        lookup_key.session_id_lo = pending->session_id_lo;
-        if (!update_map_or_fail(stats ? &stats->map_update_fail : NULL,
-                                &session_index_map,
-                                &lookup_key,
-                                &flow)) {
-            bpf_map_delete_elem(&active_session_map, &flow);
-            return XDP_DROP;
-        }
-        bpf_map_delete_elem(&pending_auth_map, &iph->saddr);
-
-        bump(stats ? &stats->protected_pass : NULL);
-        return XDP_PASS;
+        bump(stats ? &stats->protected_drop : NULL);
+        return XDP_DROP;
     }
     if (sess->expires_at_ns < now_ns) {
         lookup_key.src_ip = iph->saddr;

--- a/src/bpf/knock_kern.bpf.c
+++ b/src/bpf/knock_kern.bpf.c
@@ -359,7 +359,12 @@ int port_knock_xdp(struct xdp_md *ctx)
                 new_sess.session_id_hi = session_id_hi;
                 new_sess.session_id_lo = session_id_lo;
                 new_sess.expires_at_ns = now_ns + ((__u64)cfg->timeout_ms * 1000000ULL);
-                bpf_map_update_elem(&active_session_map, &flow, &new_sess, 0);
+                if (!update_map_or_fail(stats ? &stats->map_update_fail : NULL,
+                                        &active_session_map,
+                                        &flow,
+                                        &new_sess)) {
+                    return XDP_DROP;
+                }
 
                 lookup_key.src_ip = iph->saddr;
                 lookup_key.session_id_hi = session_id_hi;

--- a/src/user/knock_client.c
+++ b/src/user/knock_client.c
@@ -28,9 +28,10 @@ static void usage(const char *prog)
             "Usage: %s --ifname <iface> --src-ip <ip> --dst-ip <ip> --dst-port <port> --hmac-key <64-hex> [options]\n"
             "Options:\n"
             "  --src-port <port>            Source TCP port (default: 50000)\n"
-            "  --packet-type <auth|deauth>  Control packet type (default: auth)\n"
+            "  --packet-type <auth|deauth|bind>  Control packet type (default: auth)\n"
             "  --user-id <u16>              Numeric user ID (default for auth: 0)\n"
             "  --session-id <u64>           Session id (required for deauth, random for auth)\n"
+            "  --bind-port <port>           Protected service port (required for bind)\n"
             "  --nonce <u32>                Explicit nonce (default: random)\n"
             "  --timestamp-sec <u32>        Explicit monotonic timestamp (default: CLOCK_MONOTONIC)\n",
             prog);
@@ -44,6 +45,10 @@ static int parse_packet_type(const char *s, __u8 *packet_type)
     }
     if (strcmp(s, "deauth") == 0) {
         *packet_type = KNOCK_PKT_DEAUTH;
+        return 0;
+    }
+    if (strcmp(s, "bind") == 0) {
+        *packet_type = KNOCK_PKT_BIND;
         return 0;
     }
     return -1;
@@ -93,6 +98,7 @@ int main(int argc, char **argv)
         {"hmac-key", required_argument, NULL, 'k'},
         {"nonce", required_argument, NULL, 'n'},
         {"timestamp-sec", required_argument, NULL, 't'},
+        {"bind-port", required_argument, NULL, 'b'},
         {NULL, 0, NULL, 0},
     };
 
@@ -102,6 +108,7 @@ int main(int argc, char **argv)
     const char *hmac_hex = NULL;
     uint16_t src_port = 50000;
     uint16_t dst_port = KNOCK_DEFAULT_PORT;
+    uint16_t bind_port = 0;
     __u8 packet_type = KNOCK_PKT_AUTH;
     __u32 user_id = 0;
     __u64 session_id = 0;
@@ -127,7 +134,7 @@ int main(int argc, char **argv)
     int opt;
     struct ifreq ifr;
 
-    while ((opt = getopt_long(argc, argv, "i:s:d:p:q:m:u:x:k:n:t:", long_opts, NULL)) != -1) {
+    while ((opt = getopt_long(argc, argv, "i:s:d:p:q:m:u:x:k:n:t:b:", long_opts, NULL)) != -1) {
         switch (opt) {
         case 'i':
             ifname = optarg;
@@ -194,6 +201,15 @@ int main(int argc, char **argv)
             ts = (uint32_t)strtoul(optarg, NULL, 10);
             have_ts = 1;
             break;
+        case 'b': {
+            unsigned long v = strtoul(optarg, NULL, 10);
+            if (v == 0 || v > 65535UL) {
+                fprintf(stderr, "error: invalid --bind-port\n");
+                return 1;
+            }
+            bind_port = (uint16_t)v;
+            break;
+        }
         default:
             usage(argv[0]);
             return 1;
@@ -242,6 +258,16 @@ int main(int argc, char **argv)
         fprintf(stderr, "error: --session-id is required for --packet-type deauth\n");
         return 1;
     }
+    if (packet_type == KNOCK_PKT_BIND) {
+        if (!have_session_id) {
+            fprintf(stderr, "error: --session-id is required for --packet-type bind\n");
+            return 1;
+        }
+        if (bind_port == 0) {
+            fprintf(stderr, "error: --bind-port is required for --packet-type bind\n");
+            return 1;
+        }
+    }
     if (!have_nonce) {
         if (random_u32(&nonce) != 0) {
             fprintf(stderr, "error: failed to generate random nonce: %s\n", strerror(errno));
@@ -269,6 +295,10 @@ int main(int argc, char **argv)
     kpkt.packet_type = packet_type;
     kpkt.session_id_hi = htonl((__u32)(session_id >> 32));
     kpkt.session_id_lo = htonl((__u32)(session_id & 0xffffffffULL));
+    if (packet_type == KNOCK_PKT_BIND) {
+        kpkt.bind_src_port = htons(src_port);
+        kpkt.bind_dst_port = htons(bind_port);
+    }
 
     {
         struct in_addr src_addr;
@@ -284,6 +314,10 @@ int main(int argc, char **argv)
         sig_in.session_id_hi = (__u32)(session_id >> 32);
         sig_in.session_id_lo = (__u32)(session_id & 0xffffffffULL);
         sig_in.nonce = nonce;
+        if (packet_type == KNOCK_PKT_BIND) {
+            sig_in.bind_src_port = src_port;
+            sig_in.bind_dst_port = bind_port;
+        }
         knock_signature_words(key, &sig_in, sig);
 
         for (size_t i = 0; i < KNOCK_SIGNATURE_WORDS; i++) {

--- a/src/user/knock_client.c
+++ b/src/user/knock_client.c
@@ -30,7 +30,7 @@ static void usage(const char *prog)
             "  --src-port <port>            Source TCP port (default: 50000)\n"
             "  --packet-type <auth|deauth|bind>  Control packet type (default: auth)\n"
             "  --user-id <u16>              Numeric user ID (default for auth: 0)\n"
-            "  --session-id <u64>           Session id (required for deauth, random for auth)\n"
+            "  --session-id <u64>           Session id (required for deauth/bind, random for auth)\n"
             "  --bind-port <port>           Protected service port (required for bind)\n"
             "  --nonce <u32>                Explicit nonce (default: random)\n"
             "  --timestamp-sec <u32>        Explicit monotonic timestamp (default: CLOCK_MONOTONIC)\n",
@@ -165,7 +165,7 @@ int main(int argc, char **argv)
         }
         case 'm':
             if (parse_packet_type(optarg, &packet_type) != 0) {
-                fprintf(stderr, "error: --packet-type must be auth or deauth\n");
+                fprintf(stderr, "error: --packet-type must be auth, deauth, or bind\n");
                 return 1;
             }
             break;


### PR DESCRIPTION
… binding

- Updated knock_packet protocol to include KNOCK_PKT_BIND type (3)
- Add bind_src_port and bind_dst_port fields to packet and signature
- Client: Add --bind-port option to specify target protected service port
- Client: Generate bind packets with proper signature covering port tuple
- Kernel: Implement bind packet handling with full session validation
  - Lookup pending auth by session_lookup_key (src_ip + session_id_hi/lo)
  - Validate bind packet ports match actual flow
  - Only create active_session_map entry after explicit bind
- Remove auto-promotion logic from protected port path
  - Previously allowed ANY pending auth on same IP to trigger promotion
  - Now REQUIRES explicit bind packet for session-aware security

This prevents same-IP peer hijacking attacks where two clients on same IP could compete for access - now each client must send explicit bind packet with correct session_id for their specific destination port.