### PR TITLE
fix(test): Tests now handle BIND pckts corectly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,6 @@ admin-panel/backend/.env
 admin-panel/backend/.coverage
 admin-panel/**/__pycache__/
 admin-panel/**/*.pyc
+
+
+*.agent.md

--- a/scripts/test_e2e.sh
+++ b/scripts/test_e2e.sh
@@ -5,6 +5,9 @@ KEY="00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=2000
+AUTH_FLOW_SRC_PORT=55001
+REAUTH_FLOW_SRC_PORT=55002
+REPLAY_FLOW_SRC_PORT=55003
 
 if [[ "$(id -u)" -ne 0 ]]; then
     echo "error: run as root (required for XDP attach and raw knock packets)" >&2
@@ -63,6 +66,29 @@ read_stat_counter() {
         '
 }
 
+run_connect_test() {
+    local msg="$1"
+    local src_port="$2"
+
+    python3 - <<PY
+import socket
+import sys
+
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.settimeout(1.5)
+try:
+    s.bind(("127.0.0.1", int(${src_port@Q})))
+    s.connect(("127.0.0.1", 2222))
+    s.sendall(${msg@Q}.encode())
+    data = s.recv(16)
+    s.close()
+    sys.exit(0 if data == b"ok" else 1)
+except Exception:
+    sys.exit(1)
+PY
+}
+
 active_session_count() {
     local count
     count="$(bpftool map dump pinned /sys/fs/bpf/knock_gate/active_session_map 2>/dev/null | grep -c '"key"' || true)"
@@ -110,7 +136,7 @@ sock.close()
 PY
 LISTENER_PID=$!
 
-./build/knockd \
+./build/knockd daemon \
   --ifname lo \
   --hmac-key "$KEY" \
   --protect "$PROTECTED_PORT" \
@@ -123,21 +149,7 @@ LOADER_PID=$!
 sleep 2
 
 echo "[1/9] checking unauthorized access is blocked..."
-if python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(1.5)
-try:
-    s.connect(("127.0.0.1", 2222))
-    s.sendall(b"unauthorized")
-    _ = s.recv(16)
-    s.close()
-    sys.exit(0)
-except Exception:
-    sys.exit(1)
-PY
+if run_connect_test "unauthorized" "$AUTH_FLOW_SRC_PORT"
 then
     fail_with_logs "protected port accepted unauthorized client"
 else
@@ -165,26 +177,27 @@ fi
 print_section "sent knock"
 cat /tmp/knock_client_test.log
 
+echo "[bind] opening flow session for authorized checks..."
+TS_BIND="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND=424240
+./build/knock-client \
+    --ifname lo \
+    --src-ip 127.0.0.1 \
+    --dst-ip 127.0.0.1 \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$SESSION_ID" \
+    --src-port "$AUTH_FLOW_SRC_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND" \
+    --nonce "$NONCE_BIND" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_bind_test.log 2>&1
+
 sleep 1
 
 echo "[3/9] checking authorized access now succeeds..."
-python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(2.0)
-try:
-    s.connect(("127.0.0.1", 2222))
-    s.sendall(b"authorized")
-    data = s.recv(16)
-    s.close()
-    if data == b"ok":
-        sys.exit(0)
-except Exception:
-    pass
-sys.exit(1)
-PY
+run_connect_test "authorized" "$AUTH_FLOW_SRC_PORT"
 
 if [[ $? -ne 0 ]]; then
     fail_with_logs "authorized client did not reach protected port"
@@ -245,21 +258,7 @@ NONCE_DEAUTH=424243
 
 echo "[7/11] verifying deauth immediately blocks access..."
 sleep 1
-if python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(1.5)
-try:
-    s.connect(("127.0.0.1", 2222))
-    s.sendall(b"after-deauth")
-    _ = s.recv(16)
-    s.close()
-    sys.exit(0)
-except Exception:
-    sys.exit(1)
-PY
+if run_connect_test "after-deauth" "$AUTH_FLOW_SRC_PORT"
 then
     fail_with_logs "client still authorized after deauth"
 else
@@ -279,7 +278,29 @@ NONCE2=424244
   --hmac-key "$KEY" \
   >/tmp/knock_client_reauth_test.log 2>&1
 
-sleep 1
+NEW_SESSION_ID="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_reauth_test.log | head -n1)"
+if [[ -z "$NEW_SESSION_ID" ]]; then
+        fail_with_logs "unable to parse session_id from reauth output"
+fi
+
+echo "[bind] opening flow session for reauth checks..."
+TS_BIND2="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND2=424246
+./build/knock-client \
+    --ifname lo \
+    --src-ip 127.0.0.1 \
+    --dst-ip 127.0.0.1 \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$NEW_SESSION_ID" \
+    --src-port "$REAUTH_FLOW_SRC_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND2" \
+    --nonce "$NONCE_BIND2" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_reauth_bind_test.log 2>&1
+
+sleep 0.2
 
 echo "[9/11] replaying previous-session deauth must not revoke new session..."
 TS_DEAUTH_REPLAY="$(cut -d. -f1 /proc/uptime)"
@@ -296,24 +317,8 @@ NONCE_DEAUTH_REPLAY=424245
     --hmac-key "$KEY" \
     >/tmp/knock_client_deauth_replay_test.log 2>&1
 
-sleep 1
-python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(2.0)
-try:
-        s.connect(("127.0.0.1", 2222))
-        s.sendall(b"after-old-session-deauth")
-        data = s.recv(16)
-        s.close()
-        if data == b"ok":
-                sys.exit(0)
-except Exception:
-        pass
-sys.exit(1)
-PY
+sleep 0.2
+run_connect_test "after-old-session-deauth" "$REAUTH_FLOW_SRC_PORT"
 
 if [[ $? -ne 0 ]]; then
         fail_with_logs "old-session deauth revoked new active session"
@@ -329,21 +334,7 @@ echo "ok: reauthorized session is active"
 
 echo "[11/11] waiting for authorization timeout then confirming re-block..."
 sleep 3
-if python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(1.5)
-try:
-    s.connect(("127.0.0.1", 2222))
-    s.sendall(b"after-timeout")
-    _ = s.recv(16)
-    s.close()
-    sys.exit(0)
-except Exception:
-    sys.exit(1)
-PY
+if run_connect_test "after-timeout" "$REAUTH_FLOW_SRC_PORT"
 then
     fail_with_logs "client still authorized after timeout"
 else
@@ -364,21 +355,7 @@ echo "[extra] replaying the original auth knock should not reauthorize..."
 
 sleep 1
 
-if python3 - <<'PY'
-import socket
-import sys
-
-s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-s.settimeout(1.5)
-try:
-    s.connect(("127.0.0.1", 2222))
-    s.sendall(b"replay")
-    _ = s.recv(16)
-    s.close()
-    sys.exit(0)
-except Exception:
-    sys.exit(1)
-PY
+if run_connect_test "replay" "$REPLAY_FLOW_SRC_PORT"
 then
     fail_with_logs "replayed knock reauthorized client"
 else

--- a/scripts/test_e2e_netns.sh
+++ b/scripts/test_e2e_netns.sh
@@ -5,6 +5,9 @@ KEY="00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=3000
+CLIENT_FLOW_SRC_PORT=55011
+CLIENT_REAUTH_FLOW_SRC_PORT=55012
+ATTACKER_FLOW_SRC_PORT=55021
 
 CLIENT_NS="knockns-client"
 ATTACKER_NS="knockns-attacker"
@@ -102,14 +105,18 @@ PY
 run_connect_test() {
     local ns="$1"
     local msg="$2"
+    local src_ip="$3"
+    local src_port="$4"
 
     ip netns exec "$ns" python3 - <<PY
 import socket
 import sys
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.settimeout(1.5)
 try:
+    s.bind((${src_ip@Q}, int(${src_port@Q})))
     s.connect(("10.200.0.1", 2222))
     s.sendall(${msg@Q}.encode())
     data = s.recv(16)
@@ -159,7 +166,7 @@ LOADER_PID=$!
 sleep 2
 
 echo "[1/11] attacker cannot access protected port..."
-if run_connect_test "$ATTACKER_NS" "attacker-pre"; then
+if run_connect_test "$ATTACKER_NS" "attacker-pre" "$ATTACKER_IP" "$ATTACKER_FLOW_SRC_PORT"; then
     echo "fail: attacker unexpectedly reached protected service" >&2
     exit 1
 else
@@ -167,7 +174,7 @@ else
 fi
 
 echo "[2/11] client cannot access before knock..."
-if run_connect_test "$CLIENT_NS" "client-pre"; then
+if run_connect_test "$CLIENT_NS" "client-pre" "$CLIENT_IP" "$CLIENT_FLOW_SRC_PORT"; then
     echo "fail: client unexpectedly reached service before knock" >&2
     exit 1
 else
@@ -193,10 +200,26 @@ if [[ -z "$SESSION_ID" ]]; then
     exit 1
 fi
 
+TS_BIND="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND=314157
+ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
+    --ifname "$CLIENT_NS_IF" \
+    --src-ip "$CLIENT_IP" \
+    --dst-ip "$EDGE_IP" \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$SESSION_ID" \
+    --src-port "$CLIENT_FLOW_SRC_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND" \
+    --nonce "$NONCE_BIND" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_netns_bind_test.log 2>&1
+
 sleep 1
 
 echo "[4/11] client now reaches protected port..."
-if run_connect_test "$CLIENT_NS" "client-post"; then
+if run_connect_test "$CLIENT_NS" "client-post" "$CLIENT_IP" "$CLIENT_FLOW_SRC_PORT"; then
     echo "ok: client authorized"
 else
     echo "fail: client could not reach service after valid knock" >&2
@@ -204,7 +227,7 @@ else
 fi
 
 echo "[5/11] attacker remains blocked..."
-if run_connect_test "$ATTACKER_NS" "attacker-post"; then
+if run_connect_test "$ATTACKER_NS" "attacker-post" "$ATTACKER_IP" "$ATTACKER_FLOW_SRC_PORT"; then
     echo "fail: attacker gained access without authorization" >&2
     exit 1
 else
@@ -262,7 +285,7 @@ ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
 sleep 1
 
 echo "[9/11] deauth immediately blocks client..."
-if run_connect_test "$CLIENT_NS" "client-deauth"; then
+if run_connect_test "$CLIENT_NS" "client-deauth" "$CLIENT_IP" "$CLIENT_FLOW_SRC_PORT"; then
     echo "fail: client still authorized after deauth" >&2
     exit 1
 else
@@ -282,15 +305,37 @@ ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
   --hmac-key "$KEY" \
   >/tmp/knock_client_netns_reauth_test.log 2>&1
 
+REAUTH_SESSION_ID="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_netns_reauth_test.log | head -n1)"
+if [[ -z "$REAUTH_SESSION_ID" ]]; then
+        echo "fail: unable to parse session_id from netns reauth output" >&2
+        exit 1
+fi
+
+TS_BIND2="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND2=314162
+ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
+    --ifname "$CLIENT_NS_IF" \
+    --src-ip "$CLIENT_IP" \
+    --dst-ip "$EDGE_IP" \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$REAUTH_SESSION_ID" \
+    --src-port "$CLIENT_REAUTH_FLOW_SRC_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND2" \
+    --nonce "$NONCE_BIND2" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_netns_reauth_bind_test.log 2>&1
+
 sleep 1
-if ! run_connect_test "$CLIENT_NS" "client-reauth"; then
+if ! run_connect_test "$CLIENT_NS" "client-reauth" "$CLIENT_IP" "$CLIENT_REAUTH_FLOW_SRC_PORT"; then
     echo "fail: client could not reach service after reauth" >&2
     exit 1
 fi
 
 echo "[11/11] timeout expires and client is blocked again..."
 sleep 4
-if run_connect_test "$CLIENT_NS" "client-timeout"; then
+if run_connect_test "$CLIENT_NS" "client-timeout" "$CLIENT_IP" "$CLIENT_REAUTH_FLOW_SRC_PORT"; then
     echo "fail: client still authorized after timeout" >&2
     exit 1
 else

--- a/scripts/test_e2e_netns_ssh.sh
+++ b/scripts/test_e2e_netns_ssh.sh
@@ -5,6 +5,9 @@ KEY="00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff"
 PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=3000
+CLIENT_SSH_FLOW_PORT=55411
+CLIENT_REAUTH_SSH_FLOW_PORT=55412
+ATTACKER_SSH_FLOW_PORT=55421
 
 CLIENT_NS="knockns-client"
 ATTACKER_NS="knockns-attacker"
@@ -26,6 +29,7 @@ SSH_HOST_KEY="$SSH_TEST_DIR/ssh_host_ed25519_key"
 SSH_CLIENT_KEY="$SSH_TEST_DIR/client_ed25519"
 SSH_CFG="$SSH_TEST_DIR/sshd_config"
 SSH_LOG="$SSH_TEST_DIR/sshd.log"
+SSH_PROXY_HELPER="$SSH_TEST_DIR/ssh_proxy_bind.py"
 SSH_TEST_USER="${SSH_TEST_USER:-}"
 SSH_USER_HOME=""
 SSH_USER_DIR=""
@@ -169,6 +173,54 @@ StrictModes no
 LogLevel ERROR
 EOF
 
+    cat > "$SSH_PROXY_HELPER" <<'PY'
+#!/usr/bin/env python3
+import os
+import select
+import socket
+import sys
+
+if len(sys.argv) != 5:
+    sys.exit(2)
+
+host = sys.argv[1]
+port = int(sys.argv[2])
+src_ip = sys.argv[3]
+src_port = int(sys.argv[4])
+
+sock = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+sock.bind((src_ip, src_port))
+sock.connect((host, port))
+
+stdin_fd = sys.stdin.fileno()
+stdout_fd = sys.stdout.fileno()
+sock_fd = sock.fileno()
+
+while True:
+    read_fds = [sock_fd, stdin_fd]
+    ready, _, _ = select.select(read_fds, [], [])
+
+    if sock_fd in ready:
+        data = sock.recv(32768)
+        if not data:
+            break
+        os.write(stdout_fd, data)
+
+    if stdin_fd in ready:
+        data = os.read(stdin_fd, 32768)
+        if not data:
+            try:
+                sock.shutdown(socket.SHUT_WR)
+            except OSError:
+                pass
+            continue
+        sock.sendall(data)
+
+sock.close()
+PY
+    chmod 700 "$SSH_PROXY_HELPER"
+
     /usr/sbin/sshd -D -f "$SSH_CFG" -E "$SSH_LOG" &
     SSHD_PID=$!
     sleep 1
@@ -177,6 +229,8 @@ EOF
 run_ssh_test() {
     local ns="$1"
     local marker="$2"
+    local src_ip="$3"
+    local src_port="$4"
 
     ip netns exec "$ns" ssh \
         -o BatchMode=yes \
@@ -185,6 +239,7 @@ run_ssh_test() {
         -o StrictHostKeyChecking=no \
         -o UserKnownHostsFile=/dev/null \
         -o ConnectTimeout=2 \
+        -o "ProxyCommand=python3 $SSH_PROXY_HELPER %h %p $src_ip $src_port" \
         -i "$SSH_CLIENT_KEY" \
         -p "$PROTECTED_PORT" \
         "$SSH_TEST_USER"@"$EDGE_IP" \
@@ -249,7 +304,7 @@ LOADER_PID=$!
 sleep 2
 
 echo "[1/11] attacker cannot SSH before knock..."
-if run_ssh_test "$ATTACKER_NS" "attacker-pre"; then
+if run_ssh_test "$ATTACKER_NS" "attacker-pre" "$ATTACKER_IP" "$ATTACKER_SSH_FLOW_PORT"; then
     echo "fail: attacker unexpectedly reached SSH before authorization" >&2
     exit 1
 else
@@ -257,7 +312,7 @@ else
 fi
 
 echo "[2/11] client cannot SSH before knock..."
-if run_ssh_test "$CLIENT_NS" "client-pre"; then
+if run_ssh_test "$CLIENT_NS" "client-pre" "$CLIENT_IP" "$CLIENT_SSH_FLOW_PORT"; then
     echo "fail: client unexpectedly reached SSH before knock" >&2
     exit 1
 else
@@ -283,10 +338,26 @@ if [[ -z "$SESSION_ID" ]]; then
         exit 1
 fi
 
+TS_BIND="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND=271826
+ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
+    --ifname "$CLIENT_NS_IF" \
+    --src-ip "$CLIENT_IP" \
+    --dst-ip "$EDGE_IP" \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$SESSION_ID" \
+    --src-port "$CLIENT_SSH_FLOW_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND" \
+    --nonce "$NONCE_BIND" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_netns_ssh_bind_test.log 2>&1
+
 sleep 1
 
 echo "[4/11] client can SSH after valid auth..."
-if run_ssh_test "$CLIENT_NS" "client-post"; then
+if run_ssh_test "$CLIENT_NS" "client-post" "$CLIENT_IP" "$CLIENT_SSH_FLOW_PORT"; then
     echo "ok: client authorized"
 else
     echo "fail: client could not SSH after valid knock" >&2
@@ -296,7 +367,7 @@ else
 fi
 
 echo "[5/11] attacker remains blocked..."
-if run_ssh_test "$ATTACKER_NS" "attacker-post"; then
+if run_ssh_test "$ATTACKER_NS" "attacker-post" "$ATTACKER_IP" "$ATTACKER_SSH_FLOW_PORT"; then
     echo "fail: attacker gained SSH access without authorization" >&2
     exit 1
 else
@@ -354,7 +425,7 @@ ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
 sleep 1
 
 echo "[9/11] deauth immediately closes SSH access..."
-if run_ssh_test "$CLIENT_NS" "client-deauth"; then
+if run_ssh_test "$CLIENT_NS" "client-deauth" "$CLIENT_IP" "$CLIENT_SSH_FLOW_PORT"; then
     echo "fail: client still has SSH after deauth" >&2
     exit 1
 else
@@ -374,15 +445,37 @@ ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
   --hmac-key "$KEY" \
   >/tmp/knock_client_netns_ssh_reauth_test.log 2>&1
 
+REAUTH_SESSION_ID="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_netns_ssh_reauth_test.log | head -n1)"
+if [[ -z "$REAUTH_SESSION_ID" ]]; then
+        echo "fail: unable to parse session_id from SSH reauth output" >&2
+        exit 1
+fi
+
+TS_BIND2="$(cut -d. -f1 /proc/uptime)"
+NONCE_BIND2=271831
+ip netns exec "$CLIENT_NS" "$ROOT_DIR/build/knock-client" \
+    --ifname "$CLIENT_NS_IF" \
+    --src-ip "$CLIENT_IP" \
+    --dst-ip "$EDGE_IP" \
+    --dst-port "$KNOCK_PORT" \
+    --packet-type bind \
+    --session-id "$REAUTH_SESSION_ID" \
+    --src-port "$CLIENT_REAUTH_SSH_FLOW_PORT" \
+    --bind-port "$PROTECTED_PORT" \
+    --timestamp-sec "$TS_BIND2" \
+    --nonce "$NONCE_BIND2" \
+    --hmac-key "$KEY" \
+    >/tmp/knock_client_netns_ssh_reauth_bind_test.log 2>&1
+
 sleep 1
-if ! run_ssh_test "$CLIENT_NS" "client-reauth"; then
+if ! run_ssh_test "$CLIENT_NS" "client-reauth" "$CLIENT_IP" "$CLIENT_REAUTH_SSH_FLOW_PORT"; then
     echo "fail: client could not SSH after reauth" >&2
     exit 1
 fi
 
 echo "[11/11] authorization timeout closes SSH access again..."
 sleep 4
-if run_ssh_test "$CLIENT_NS" "client-timeout"; then
+if run_ssh_test "$CLIENT_NS" "client-timeout" "$CLIENT_IP" "$CLIENT_REAUTH_SSH_FLOW_PORT"; then
     echo "fail: client still has SSH after timeout" >&2
     exit 1
 else

--- a/scripts/test_e2e_user_admin.sh
+++ b/scripts/test_e2e_user_admin.sh
@@ -7,6 +7,7 @@ KEY_USER200_V2="33445566778899001122aabbccddeeff33445566778899001122aabbccddeeff
 PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=2500
+FLOW_SRC_PORT=55300
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -18,13 +19,17 @@ require_root() {
 }
 
 run_connect_test() {
-    python3 - <<'PY'
+    local src_port="$1"
+
+    python3 - <<PY
 import socket
 import sys
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.settimeout(1.5)
 try:
+    s.bind(("127.0.0.1", int(${src_port@Q})))
     s.connect(("127.0.0.1", 2222))
     s.sendall(b"probe")
     data = s.recv(16)
@@ -33,6 +38,31 @@ try:
 except Exception:
     sys.exit(1)
 PY
+}
+
+send_bind_knock() {
+    local session_id="$1"
+    local src_port="$2"
+    local nonce="$3"
+    local hmac_key="$4"
+    local out_file="$5"
+    local ts
+
+    ts="$(cut -d. -f1 /proc/uptime)"
+
+    ./build/knock-client \
+        --ifname lo \
+        --src-ip 127.0.0.1 \
+        --dst-ip 127.0.0.1 \
+        --dst-port "$KNOCK_PORT" \
+        --packet-type bind \
+        --session-id "$session_id" \
+        --src-port "$src_port" \
+        --bind-port "$PROTECTED_PORT" \
+        --timestamp-sec "$ts" \
+        --nonce "$nonce" \
+        --hmac-key "$hmac_key" \
+        >"$out_file" 2>&1
 }
 
 fail_with_logs() {
@@ -131,8 +161,13 @@ echo "[4/11] user 200 can authenticate immediately..."
     --user-id 200 \
     --hmac-key "$KEY_USER200" \
     >/tmp/knock_admin_user200_ok.log 2>&1
+SESSION_200_A="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_admin_user200_ok.log | head -n1)"
+if [[ -z "$SESSION_200_A" ]]; then
+    fail_with_logs "unable to parse session id for user 200 auth"
+fi
+send_bind_knock "$SESSION_200_A" "$FLOW_SRC_PORT" 999100 "$KEY_USER200" /tmp/knock_admin_user200_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "user 200 was not authorized after live registration"
 fi
 echo "ok: live-registered user can authenticate"
@@ -179,8 +214,13 @@ fi
     --user-id 200 \
     --hmac-key "$KEY_USER200_V2" \
     >/tmp/knock_admin_user200_v2.log 2>&1
+SESSION_200_B="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_admin_user200_v2.log | head -n1)"
+if [[ -z "$SESSION_200_B" ]]; then
+    fail_with_logs "unable to parse session id for user 200 rotated auth"
+fi
+send_bind_knock "$SESSION_200_B" "$FLOW_SRC_PORT" 999101 "$KEY_USER200_V2" /tmp/knock_admin_user200_v2_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "user 200 new key did not authenticate"
 fi
 echo "ok: rotated key works"
@@ -205,7 +245,7 @@ echo "[10/11] revoked user 200 can no longer authenticate..."
     --hmac-key "$KEY_USER200_V2" \
     >/tmp/knock_admin_user200_revoked.log 2>&1
 sleep 1
-if run_connect_test; then
+if run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "revoked user 200 still gained access"
 fi
 echo "ok: revoked user blocked"

--- a/scripts/test_e2e_user_auth.sh
+++ b/scripts/test_e2e_user_auth.sh
@@ -8,6 +8,8 @@ PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=1500
 BIND_WINDOW_MS=1500
+FLOW_USER100_PORT=55100
+FLOW_USER101_PORT=55101
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -43,13 +45,17 @@ read_stat_counter() {
 }
 
 run_connect_test() {
-    python3 - <<'PY'
+    local src_port="$1"
+
+    python3 - <<PY
 import socket
 import sys
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.settimeout(1.5)
 try:
+    s.bind(("127.0.0.1", int(${src_port@Q})))
     s.connect(("127.0.0.1", 2222))
     s.sendall(b"probe")
     data = s.recv(16)
@@ -58,6 +64,31 @@ try:
 except Exception:
     sys.exit(1)
 PY
+}
+
+send_bind_knock() {
+    local session_id="$1"
+    local src_port="$2"
+    local nonce="$3"
+    local hmac_key="$4"
+    local out_file="$5"
+    local ts
+
+    ts="$(cut -d. -f1 /proc/uptime)"
+
+    ./build/knock-client \
+        --ifname lo \
+        --src-ip 127.0.0.1 \
+        --dst-ip 127.0.0.1 \
+        --dst-port "$KNOCK_PORT" \
+        --packet-type bind \
+        --session-id "$session_id" \
+        --src-port "$src_port" \
+        --bind-port "$PROTECTED_PORT" \
+        --timestamp-sec "$ts" \
+        --nonce "$nonce" \
+        --hmac-key "$hmac_key" \
+        >"$out_file" 2>&1
 }
 
 fail_with_logs() {
@@ -125,7 +156,7 @@ LOADER_PID=$!
 sleep 2
 
 echo "[1/8] unauthorized access is blocked..."
-if run_connect_test; then
+if run_connect_test "$FLOW_USER100_PORT"; then
     fail_with_logs "protected service accepted connection before knock"
 fi
 echo "ok: blocked before knock"
@@ -139,8 +170,13 @@ echo "[2/8] user 100 with correct key can authenticate..."
     --user-id 100 \
     --hmac-key "$KEY_USER100" \
     >/tmp/knock_client_user100_ok.log 2>&1
+SESSION_100="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_user100_ok.log | head -n1)"
+if [[ -z "$SESSION_100" ]]; then
+    fail_with_logs "unable to parse session id for user 100 auth"
+fi
+send_bind_knock "$SESSION_100" "$FLOW_USER100_PORT" 777100 "$KEY_USER100" /tmp/knock_client_user100_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_USER100_PORT"; then
     fail_with_logs "user 100 was not authorized"
 fi
 echo "ok: user 100 authorized"
@@ -148,7 +184,7 @@ echo "ok: user 100 authorized"
 sleep 2
 
 echo "[3/8] session times out and access closes..."
-if run_connect_test; then
+if run_connect_test "$FLOW_USER100_PORT"; then
     fail_with_logs "session should have timed out"
 fi
 echo "ok: timeout enforced"
@@ -168,7 +204,7 @@ UNKNOWN_AFTER="$(read_stat_counter unknown_user)"
 if [[ "$UNKNOWN_AFTER" -le "$UNKNOWN_BEFORE" ]]; then
     fail_with_logs "unknown_user counter did not increment"
 fi
-if run_connect_test; then
+if run_connect_test "$FLOW_USER100_PORT"; then
     fail_with_logs "unknown user should not gain access"
 fi
 echo "ok: unknown user rejected"
@@ -186,8 +222,9 @@ SESSION_101_A="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_clien
 if [[ -z "$SESSION_101_A" ]]; then
     fail_with_logs "unable to parse session id for user 101 auth"
 fi
+send_bind_knock "$SESSION_101_A" "$FLOW_USER101_PORT" 777101 "$KEY_USER101" /tmp/knock_client_user101_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_USER101_PORT"; then
     fail_with_logs "user 101 was not authorized with correct key"
 fi
 echo "ok: user 101 authorized"
@@ -272,7 +309,7 @@ NONCE_DEAUTH=777002
     >/tmp/knock_client_deauth_101.log 2>&1
 
 sleep 1
-if run_connect_test; then
+if run_connect_test "$FLOW_USER101_PORT"; then
     fail_with_logs "service should be blocked after deauth"
 fi
 echo "ok: deauth immediately revokes active auth"

--- a/scripts/test_e2e_user_rotation.sh
+++ b/scripts/test_e2e_user_rotation.sh
@@ -7,6 +7,7 @@ PROTECTED_PORT=2222
 KNOCK_PORT=40000
 TIMEOUT_MS=1400
 GRACE_MS=2500
+FLOW_SRC_PORT=55200
 
 ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
 
@@ -37,13 +38,17 @@ read_stat_counter() {
 }
 
 run_connect_test() {
-    python3 - <<'PY'
+    local src_port="$1"
+
+    python3 - <<PY
 import socket
 import sys
 
 s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
 s.settimeout(1.5)
 try:
+    s.bind(("127.0.0.1", int(${src_port@Q})))
     s.connect(("127.0.0.1", 2222))
     s.sendall(b"probe")
     data = s.recv(16)
@@ -52,6 +57,31 @@ try:
 except Exception:
     sys.exit(1)
 PY
+}
+
+send_bind_knock() {
+    local session_id="$1"
+    local src_port="$2"
+    local nonce="$3"
+    local hmac_key="$4"
+    local out_file="$5"
+    local ts
+
+    ts="$(cut -d. -f1 /proc/uptime)"
+
+    ./build/knock-client \
+        --ifname lo \
+        --src-ip 127.0.0.1 \
+        --dst-ip 127.0.0.1 \
+        --dst-port "$KNOCK_PORT" \
+        --packet-type bind \
+        --session-id "$session_id" \
+        --src-port "$src_port" \
+        --bind-port "$PROTECTED_PORT" \
+        --timestamp-sec "$ts" \
+        --nonce "$nonce" \
+        --hmac-key "$hmac_key" \
+        >"$out_file" 2>&1
 }
 
 fail_with_logs() {
@@ -127,8 +157,13 @@ echo "[1/9] baseline: user 100 with key v1 authenticates..."
     --user-id 100 \
     --hmac-key "$KEY_V1" \
     >/tmp/knock_client_rot_v1_ok.log 2>&1
+SESSION_V1="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_rot_v1_ok.log | head -n1)"
+if [[ -z "$SESSION_V1" ]]; then
+    fail_with_logs "unable to parse session id for key v1 auth"
+fi
+send_bind_knock "$SESSION_V1" "$FLOW_SRC_PORT" 888100 "$KEY_V1" /tmp/knock_client_rot_v1_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "key v1 auth failed before rotation"
 fi
 echo "ok: key v1 works"
@@ -153,8 +188,13 @@ echo "[3/9] old key is accepted during grace..."
     --user-id 100 \
     --hmac-key "$KEY_V1" \
     >/tmp/knock_client_rot_old_in_grace.log 2>&1
+SESSION_GRACE="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_rot_old_in_grace.log | head -n1)"
+if [[ -z "$SESSION_GRACE" ]]; then
+    fail_with_logs "unable to parse session id for grace auth"
+fi
+send_bind_knock "$SESSION_GRACE" "$FLOW_SRC_PORT" 888101 "$KEY_V1" /tmp/knock_client_rot_old_in_grace_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "old key should be accepted during grace"
 fi
 GRACE_AFTER="$(read_stat_counter grace_key_used)"
@@ -175,7 +215,7 @@ echo "[4/9] after grace expiry, old key must fail..."
     --hmac-key "$KEY_V1" \
     >/tmp/knock_client_rot_old_after_grace.log 2>&1
 sleep 1
-if run_connect_test; then
+if run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "old key still authorized after grace expiry"
 fi
 echo "ok: old key rejected after grace"
@@ -190,7 +230,7 @@ echo "[5/9] key mismatch counter moves on expired old key..."
     --hmac-key "$KEY_V1" \
     >/tmp/knock_client_rot_old_after_grace_2.log 2>&1
 sleep 1
-if run_connect_test; then
+if run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "expired old key unexpectedly authorized access"
 fi
 echo "ok: expired old key remains rejected"
@@ -204,8 +244,13 @@ echo "[6/9] new key works after rotation..."
     --user-id 100 \
     --hmac-key "$KEY_V2" \
     >/tmp/knock_client_rot_v2_ok.log 2>&1
+SESSION_V2="$(sed -n 's/.*session_id=\([0-9][0-9]*\).*/\1/p' /tmp/knock_client_rot_v2_ok.log | head -n1)"
+if [[ -z "$SESSION_V2" ]]; then
+    fail_with_logs "unable to parse session id for key v2 auth"
+fi
+send_bind_knock "$SESSION_V2" "$FLOW_SRC_PORT" 888102 "$KEY_V2" /tmp/knock_client_rot_v2_bind.log
 sleep 1
-if ! run_connect_test; then
+if ! run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "new key not accepted after rotation"
 fi
 echo "ok: new key accepted"
@@ -240,7 +285,7 @@ fi
     --hmac-key "$KEY_V2" \
     >/tmp/knock_client_revoked.log 2>&1
 sleep 1
-if run_connect_test; then
+if run_connect_test "$FLOW_SRC_PORT"; then
     fail_with_logs "revoked user still authorized"
 fi
 echo "ok: revoked user blocked"

--- a/src/user/knock_client.c
+++ b/src/user/knock_client.c
@@ -379,9 +379,10 @@ int main(int argc, char **argv)
     }
 
     close(fd);
-        printf("Knock frame sent on %s to %s:%u from %s:%u\n", ifname, dst_ip_str, dst_port, src_ip_str, src_port);
-        printf("type=%s timestamp=%u session_id=%" PRIu64 " nonce=%u sig=%08x:%08x:%08x:%08x\n",
-               packet_type == KNOCK_PKT_DEAUTH ? "deauth" : "auth",
+         printf("Knock frame sent on %s to %s:%u from %s:%u\n", ifname, dst_ip_str, dst_port, src_ip_str, src_port);
+         printf("type=%s timestamp=%u session_id=%" PRIu64 " nonce=%u sig=%08x:%08x:%08x:%08x\n",
+             packet_type == KNOCK_PKT_DEAUTH ? "deauth" :
+             (packet_type == KNOCK_PKT_BIND ? "bind" : "auth"),
             ts,
             (uint64_t)session_id,
             nonce,


### PR DESCRIPTION
This pull request significantly improves the reliability and thoroughness of end-to-end tests for the port knocking system by enforcing explicit source port binding for all client and attacker flows. It introduces helper functions and scripts to ensure that each test scenario uses a unique source port, which is critical for accurately simulating real-world session behavior, especially for authorization, deauthorization, and replay attack scenarios. The changes also refactor and deduplicate connection logic, add a custom SSH proxy helper for SSH-based tests, and enhance test robustness by verifying session IDs after reauthorization.

Key improvements include:

**Test Coverage and Flow Simulation Enhancements**
* All test scripts (`test_e2e.sh`, `test_e2e_netns.sh`, `test_e2e_netns_ssh.sh`) now bind client and attacker connections to explicit, unique source ports for each flow (e.g., `AUTH_FLOW_SRC_PORT`, `CLIENT_FLOW_SRC_PORT`, etc.), ensuring accurate session tracking and preventing false positives/negatives in authorization checks. [[1]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bR8-R10) [[2]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R8-R10) [[3]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R8-R10)
* For each new or reauthorized session, a "bind" packet is sent using the correct source port before access attempts, closely matching the production flow and preventing accidental session reuse. [[1]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bR180-R200) [[2]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL282-R303) [[3]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R203-R230) [[4]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R308-R338) [[5]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R341-R360) [[6]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R448-R478)

**Code Reuse and Refactoring**
* Connection attempts in `test_e2e.sh` are centralized into a new `run_connect_test` helper function, replacing multiple inline Python scripts and reducing duplication. [[1]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bR69-R91) [[2]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL126-R152) [[3]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bR180-R200) [[4]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL248-R261) [[5]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL299-R321) [[6]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL332-R337) [[7]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL367-R358)
* The netns and SSH test scripts (`test_e2e_netns.sh`, `test_e2e_netns_ssh.sh`) update their connection helpers (`run_connect_test`, `run_ssh_test`) to accept source IP and port arguments, ensuring all test flows use the correct source address. [[1]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R108-R119) [[2]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0L162-R177) [[3]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R203-R230) [[4]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0L265-R288) [[5]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R308-R338) [[6]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R232-R233) [[7]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R242) [[8]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5L252-R315) [[9]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R341-R360) [[10]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5L299-R370) [[11]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5L357-R428) [[12]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R448-R478)

**SSH Test Improvements**
* A new `ssh_proxy_bind.py` helper is introduced, allowing SSH connections to originate from a specified source port, which is essential for session isolation in SSH-based tests. The SSH test script is updated to use this proxy via the `ProxyCommand` option. [[1]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R32) [[2]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R176-R223) [[3]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R242)

**Robustness and Error Checking**
* After reauthorization, scripts now parse and verify the new session ID before proceeding, ensuring tests do not continue with invalid or missing session states. [[1]](diffhunk://#diff-2b9ef6b3174e1d6176a202f0a908365557700f8b614fa619e53cffcab1a15a3bL282-R303) [[2]](diffhunk://#diff-338251384eda73283b0821b294055f6a91d8ce2fc35b4c82e6550b0db50043c0R308-R338) [[3]](diffhunk://#diff-51af9cdd2f0be1f4f2d35765b0011523922c557a5f6cb697fe7c999370612fb5R448-R478)

These changes together make the test suite more accurate, maintainable, and reflective of real deployment scenarios, reducing the risk of undetected regressions in session handling and authorization logic.