### PR TITLE
fix(security): replace SipHash knock MAC with HMAC-SHA256

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository is a starter for a stealth gate model:
 
 - Device appears closed to unauthorized clients.
 - A client sends one special TCP packet to a dedicated knock port.
-- The knock includes a keyed signature over packet metadata.
+- The knock includes an HMAC-SHA256-based keyed signature over packet metadata.
 - If signature is valid for a registered user, that source IP is temporarily allowed to reach protected service ports.
 - Knock timestamps use Unix epoch seconds, with the XDP program comparing against a loader-seeded realtime offset derived from host clocks.
 
@@ -128,7 +128,6 @@ sudo ./build/knockd list-users
 
 <!-- ## next milestones
 
-1. Add RFC HMAC-SHA256 mode as an optional protocol variant for interoperability.
-2. Add integration tests in Linux network namespaces to validate behavior across virtual hosts.
-3. Add key rotation support with dual active keys for zero-downtime updates.
-4. Export structured observability (map stats scrape + optional userspace metrics endpoint). -->
+1. Add integration tests in Linux network namespaces to validate behavior across virtual hosts.
+2. Add key rotation support with dual active keys for zero-downtime updates.
+3. Export structured observability (map stats scrape + optional userspace metrics endpoint). -->

--- a/include/knock_crypto.h
+++ b/include/knock_crypto.h
@@ -14,77 +14,163 @@ struct knock_sig_input {
     __u16 bind_dst_port;
 };
 
-static __inline __u64 knock_rotl64(__u64 x, __u8 b)
+static const __u32 knock_sha256_k[64] = {
+    0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
+    0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
+    0xd807aa98U, 0x12835b01U, 0x243185beU, 0x550c7dc3U,
+    0x72be5d74U, 0x80deb1feU, 0x9bdc06a7U, 0xc19bf174U,
+    0xe49b69c1U, 0xefbe4786U, 0x0fc19dc6U, 0x240ca1ccU,
+    0x2de92c6fU, 0x4a7484aaU, 0x5cb0a9dcU, 0x76f988daU,
+    0x983e5152U, 0xa831c66dU, 0xb00327c8U, 0xbf597fc7U,
+    0xc6e00bf3U, 0xd5a79147U, 0x06ca6351U, 0x14292967U,
+    0x27b70a85U, 0x2e1b2138U, 0x4d2c6dfcU, 0x53380d13U,
+    0x650a7354U, 0x766a0abbU, 0x81c2c92eU, 0x92722c85U,
+    0xa2bfe8a1U, 0xa81a664bU, 0xc24b8b70U, 0xc76c51a3U,
+    0xd192e819U, 0xd6990624U, 0xf40e3585U, 0x106aa070U,
+    0x19a4c116U, 0x1e376c08U, 0x2748774cU, 0x34b0bcb5U,
+    0x391c0cb3U, 0x4ed8aa4aU, 0x5b9cca4fU, 0x682e6ff3U,
+    0x748f82eeU, 0x78a5636fU, 0x84c87814U, 0x8cc70208U,
+    0x90befffaU, 0xa4506cebU, 0xbef9a3f7U, 0xc67178f2U,
+};
+
+static __inline __u32 knock_rotr32(__u32 x, __u8 n)
 {
-    return (x << b) | (x >> (64U - b));
+    return (x >> n) | (x << (32U - n));
 }
 
-static __inline __u64 knock_load_be64(const __u8 *p)
+static __inline __u32 knock_load_be32(const __u8 *p)
 {
-    return ((__u64)p[0] << 56) | ((__u64)p[1] << 48) |
-           ((__u64)p[2] << 40) | ((__u64)p[3] << 32) |
-           ((__u64)p[4] << 24) | ((__u64)p[5] << 16) |
-           ((__u64)p[6] << 8) | (__u64)p[7];
+    return ((__u32)p[0] << 24) | ((__u32)p[1] << 16) |
+           ((__u32)p[2] << 8) | (__u32)p[3];
 }
 
-#define KNOCK_SIPROUND(v0, v1, v2, v3) \
-    do { \
-        (v0) += (v1); \
-        (v1) = knock_rotl64((v1), 13); \
-        (v1) ^= (v0); \
-        (v0) = knock_rotl64((v0), 32); \
-        (v2) += (v3); \
-        (v3) = knock_rotl64((v3), 16); \
-        (v3) ^= (v2); \
-        (v0) += (v3); \
-        (v3) = knock_rotl64((v3), 21); \
-        (v3) ^= (v0); \
-        (v2) += (v1); \
-        (v1) = knock_rotl64((v1), 17); \
-        (v1) ^= (v2); \
-        (v2) = knock_rotl64((v2), 32); \
-    } while (0)
-
-static __inline __u64 knock_siphash24_16b(__u64 k0, __u64 k1, __u64 m0, __u64 m1, __u64 tweak)
+static __inline void knock_store_be32(__u8 *dst, __u32 v)
 {
-    __u64 v0 = 0x736f6d6570736575ULL ^ k0 ^ tweak;
-    __u64 v1 = 0x646f72616e646f6dULL ^ k1;
-    __u64 v2 = 0x6c7967656e657261ULL ^ k0;
-    __u64 v3 = 0x7465646279746573ULL ^ k1 ^ (~tweak);
-    __u64 b = 16ULL << 56;
+    dst[0] = (__u8)(v >> 24);
+    dst[1] = (__u8)(v >> 16);
+    dst[2] = (__u8)(v >> 8);
+    dst[3] = (__u8)(v & 0xffU);
+}
 
-    v3 ^= m0;
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    v0 ^= m0;
+static __inline void knock_store_be64(__u8 *dst, __u64 v)
+{
+    dst[0] = (__u8)(v >> 56);
+    dst[1] = (__u8)(v >> 48);
+    dst[2] = (__u8)(v >> 40);
+    dst[3] = (__u8)(v >> 32);
+    dst[4] = (__u8)(v >> 24);
+    dst[5] = (__u8)(v >> 16);
+    dst[6] = (__u8)(v >> 8);
+    dst[7] = (__u8)(v & 0xffU);
+}
 
-    v3 ^= m1;
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    v0 ^= m1;
+static __inline __u32 knock_sha256_ch(__u32 x, __u32 y, __u32 z)
+{
+    return (x & y) ^ ((~x) & z);
+}
 
-    v3 ^= b;
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    v0 ^= b;
+static __inline __u32 knock_sha256_maj(__u32 x, __u32 y, __u32 z)
+{
+    return (x & y) ^ (x & z) ^ (y & z);
+}
 
-    v2 ^= 0xff;
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
-    KNOCK_SIPROUND(v0, v1, v2, v3);
+static __inline __u32 knock_sha256_big_sigma0(__u32 x)
+{
+    return knock_rotr32(x, 2) ^ knock_rotr32(x, 13) ^ knock_rotr32(x, 22);
+}
 
-    return v0 ^ v1 ^ v2 ^ v3;
+static __inline __u32 knock_sha256_big_sigma1(__u32 x)
+{
+    return knock_rotr32(x, 6) ^ knock_rotr32(x, 11) ^ knock_rotr32(x, 25);
+}
+
+static __inline __u32 knock_sha256_small_sigma0(__u32 x)
+{
+    return knock_rotr32(x, 7) ^ knock_rotr32(x, 18) ^ (x >> 3);
+}
+
+static __inline __u32 knock_sha256_small_sigma1(__u32 x)
+{
+    return knock_rotr32(x, 17) ^ knock_rotr32(x, 19) ^ (x >> 10);
+}
+
+static __inline void knock_sha256_init(__u32 state[8])
+{
+    state[0] = 0x6a09e667U;
+    state[1] = 0xbb67ae85U;
+    state[2] = 0x3c6ef372U;
+    state[3] = 0xa54ff53aU;
+    state[4] = 0x510e527fU;
+    state[5] = 0x9b05688cU;
+    state[6] = 0x1f83d9abU;
+    state[7] = 0x5be0cd19U;
+}
+
+static __inline void knock_sha256_transform(__u32 state[8], const __u8 block[64])
+{
+    __u32 a = state[0];
+    __u32 b = state[1];
+    __u32 c = state[2];
+    __u32 d = state[3];
+    __u32 e = state[4];
+    __u32 f = state[5];
+    __u32 g = state[6];
+    __u32 h = state[7];
+    __u32 w[16];
+    __u32 i;
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 16; i++) {
+        w[i] = knock_load_be32(&block[i * 4]);
+    }
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        __u32 s0;
+        __u32 s1;
+        __u32 t1;
+        __u32 t2;
+        __u32 wi;
+
+        if (i >= 16) {
+            s0 = knock_sha256_small_sigma0(w[(i - 15) & 15]);
+            s1 = knock_sha256_small_sigma1(w[(i - 2) & 15]);
+            w[i & 15] = w[i & 15] + s0 + w[(i - 7) & 15] + s1;
+        }
+        wi = w[i & 15];
+        t1 = h + knock_sha256_big_sigma1(e) + knock_sha256_ch(e, f, g) +
+             knock_sha256_k[i] + wi;
+        t2 = knock_sha256_big_sigma0(a) + knock_sha256_maj(a, b, c);
+
+        h = g;
+        g = f;
+        f = e;
+        e = d + t1;
+        d = c;
+        c = b;
+        b = a;
+        a = t1 + t2;
+    }
+
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    state[5] += f;
+    state[6] += g;
+    state[7] += h;
 }
 
 static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
                                            const struct knock_sig_input *in,
                                            __u32 out[KNOCK_SIGNATURE_WORDS])
 {
-    __u64 k0 = knock_load_be64(&key[0]);
-    __u64 k1 = knock_load_be64(&key[8]);
-    __u64 k2 = knock_load_be64(&key[16]);
-    __u64 k3 = knock_load_be64(&key[24]);
+    __u32 state[8];
+    __u32 inner_digest[8];
+    __u8 block[64] = {};
+    __u64 padded_len_bits = (64ULL + 32ULL) * 8ULL;
+    __u32 i;
     __u64 m0 = ((__u64)in->timestamp_sec << 32) | (__u64)in->nonce;
     __u64 m1 = ((__u64)KNOCK_MAGIC << 32) |
                ((__u64)in->packet_type << 24) |
@@ -95,15 +181,68 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
                (__u64)(in->bind_dst_port >> 8);
     __u64 m3 = ((__u64)(in->bind_dst_port & 0x00ffU) << 56) |
                0x0053474e31ULL;
-    __u64 h0 = knock_siphash24_16b(k0 ^ k2, k1 ^ k3, m0, m1, 0x0101010101010101ULL);
-    __u64 h1 = knock_siphash24_16b(k0 ^ ~k2, k1 ^ ~k3, m2, m3, 0x0202020202020202ULL);
 
-    out[0] = (__u32)(h0 >> 32);
-    out[1] = (__u32)(h0 & 0xffffffffU);
-    out[2] = (__u32)(h1 >> 32);
-    out[3] = (__u32)(h1 & 0xffffffffU);
+#pragma clang loop unroll(full)
+    for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
+        block[i] = key[i];
+    }
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        block[i] ^= 0x36U;
+    }
+
+    knock_sha256_init(state);
+    knock_sha256_transform(state, block);
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        block[i] = 0;
+    }
+    knock_store_be64(&block[0], m0);
+    knock_store_be64(&block[8], m1);
+    knock_store_be64(&block[16], m2);
+    knock_store_be64(&block[24], m3);
+    block[32] = 0x80U;
+    knock_store_be64(&block[56], padded_len_bits);
+    knock_sha256_transform(state, block);
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 8; i++) {
+        inner_digest[i] = state[i];
+    }
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        block[i] = 0;
+    }
+#pragma clang loop unroll(full)
+    for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
+        block[i] = key[i];
+    }
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        block[i] ^= 0x5cU;
+    }
+
+    knock_sha256_init(state);
+    knock_sha256_transform(state, block);
+
+#pragma clang loop unroll(full)
+    for (i = 0; i < 64; i++) {
+        block[i] = 0;
+    }
+#pragma clang loop unroll(full)
+    for (i = 0; i < 8; i++) {
+        knock_store_be32(&block[i * 4], inner_digest[i]);
+    }
+    block[32] = 0x80U;
+    knock_store_be64(&block[56], padded_len_bits);
+    knock_sha256_transform(state, block);
+
+    out[0] = state[0];
+    out[1] = state[1];
+    out[2] = state[2];
+    out[3] = state[3];
 }
-
-#undef KNOCK_SIPROUND
 
 #endif /* KNOCK_CRYPTO_H */

--- a/include/knock_crypto.h
+++ b/include/knock_crypto.h
@@ -119,12 +119,10 @@ static __inline void knock_sha256_transform(__u32 state[8], const __u8 block[64]
     __u32 w[16];
     __u32 i;
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 16; i++) {
         w[i] = knock_load_be32(&block[i * 4]);
     }
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         __u32 s0;
         __u32 s1;
@@ -182,11 +180,9 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     __u64 m3 = ((__u64)(in->bind_dst_port & 0x00ffU) << 56) |
                0x0053474e31ULL;
 
-#pragma clang loop unroll(full)
     for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
         block[i] = key[i];
     }
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         block[i] ^= 0x36U;
     }
@@ -194,7 +190,6 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     knock_sha256_init(state);
     knock_sha256_transform(state, block);
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         block[i] = 0;
     }
@@ -206,20 +201,16 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     knock_store_be64(&block[56], padded_len_bits);
     knock_sha256_transform(state, block);
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 8; i++) {
         inner_digest[i] = state[i];
     }
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         block[i] = 0;
     }
-#pragma clang loop unroll(full)
     for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
         block[i] = key[i];
     }
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         block[i] ^= 0x5cU;
     }
@@ -227,11 +218,9 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     knock_sha256_init(state);
     knock_sha256_transform(state, block);
 
-#pragma clang loop unroll(full)
     for (i = 0; i < 64; i++) {
         block[i] = 0;
     }
-#pragma clang loop unroll(full)
     for (i = 0; i < 8; i++) {
         knock_store_be32(&block[i * 4], inner_digest[i]);
     }


### PR DESCRIPTION
## Summary
- replace the custom SipHash-based knock signature construction with RFC 2104 HMAC-SHA256 in the shared primitive
- preserve existing packet wire format by transmitting the first 128 bits (4 x u32 words) of the digest
- update documentation wording to reflect HMAC-SHA256 usage

## Why
Issue #13 flags the prior custom SipHash construction as non-standard for security-critical authentication.

## Validation
- make clean && make all
- make unit-test

Closes #13