### PR TITLE
test(unit): expand userspace coverage for knock client/daemon/crypto

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,10 +17,13 @@ KNOCKD_SRCS := src/user/knock_user.c src/user/xdp_loader.c $(USER_COMMON_SRCS)
 KNOCK_CLIENT_SRCS := src/user/knock_client.c src/user/net_checksum.c $(USER_COMMON_SRCS)
 UNIT_TEST_CLI_COMMON := $(BUILD_DIR)/test_cli_common
 UNIT_TEST_NET_CHECKSUM := $(BUILD_DIR)/test_net_checksum
+UNIT_TEST_KNOCK_CRYPTO := $(BUILD_DIR)/test_knock_crypto
+UNIT_TEST_KNOCK_USER := $(BUILD_DIR)/test_knock_user
+UNIT_TEST_KNOCK_CLIENT := $(BUILD_DIR)/test_knock_client
 
 .PHONY: all clean run test test-netns test-ssh test-user-auth test-user-rotation test-user-admin test-user-all test-user-pressure test-config unit-test all-test help
 
-all: $(BPF_OBJ) $(USER_BIN) $(KNOCK_CLIENT_BIN) $(UNIT_TEST_CLI_COMMON) $(UNIT_TEST_NET_CHECKSUM)
+all: $(BPF_OBJ) $(USER_BIN) $(KNOCK_CLIENT_BIN) $(UNIT_TEST_CLI_COMMON) $(UNIT_TEST_NET_CHECKSUM) $(UNIT_TEST_KNOCK_CRYPTO) $(UNIT_TEST_KNOCK_USER) $(UNIT_TEST_KNOCK_CLIENT)
 
 help:
 	@echo "Targets:"
@@ -60,6 +63,15 @@ $(UNIT_TEST_CLI_COMMON): tests/test_cli_common.c src/user/cli_common.c include/s
 $(UNIT_TEST_NET_CHECKSUM): tests/test_net_checksum.c src/user/net_checksum.c src/user/net_checksum.h | $(BUILD_DIR)
 	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_net_checksum.c src/user/net_checksum.c -o $(UNIT_TEST_NET_CHECKSUM)
 
+$(UNIT_TEST_KNOCK_CRYPTO): tests/test_knock_crypto.c include/shared.h include/knock_crypto.h | $(BUILD_DIR)
+	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_crypto.c -o $(UNIT_TEST_KNOCK_CRYPTO)
+
+$(UNIT_TEST_KNOCK_USER): tests/test_knock_user.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/xdp_loader.h | $(BUILD_DIR)
+	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_user.c src/user/cli_common.c -o $(UNIT_TEST_KNOCK_USER)
+
+$(UNIT_TEST_KNOCK_CLIENT): tests/test_knock_client.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/net_checksum.h | $(BUILD_DIR)
+	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_client.c src/user/cli_common.c -o $(UNIT_TEST_KNOCK_CLIENT)
+
 run: all
 	@if [ -z "$(IFACE)" ] || [ -z "$(USERS_FILE)" ] || [ -z "$(PROTECT)" ]; then \
 		echo "error: set IFACE, USERS_FILE and PROTECT"; \
@@ -97,9 +109,12 @@ test-config: all
 test-user-pressure: all
 	sudo bash ./scripts/test_e2e_user_pressure.sh
 
-unit-test: $(UNIT_TEST_CLI_COMMON) $(UNIT_TEST_NET_CHECKSUM)
+unit-test: $(UNIT_TEST_CLI_COMMON) $(UNIT_TEST_NET_CHECKSUM) $(UNIT_TEST_KNOCK_CRYPTO) $(UNIT_TEST_KNOCK_USER) $(UNIT_TEST_KNOCK_CLIENT)
 	./$(UNIT_TEST_CLI_COMMON)
 	./$(UNIT_TEST_NET_CHECKSUM)
+	./$(UNIT_TEST_KNOCK_CRYPTO)
+	./$(UNIT_TEST_KNOCK_USER)
+	./$(UNIT_TEST_KNOCK_CLIENT)
 
 test-user-all: test-user-auth test-user-rotation test-user-admin
 

--- a/Makefile
+++ b/Makefile
@@ -66,10 +66,10 @@ $(UNIT_TEST_NET_CHECKSUM): tests/test_net_checksum.c src/user/net_checksum.c src
 $(UNIT_TEST_KNOCK_CRYPTO): tests/test_knock_crypto.c include/shared.h include/knock_crypto.h | $(BUILD_DIR)
 	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_crypto.c -o $(UNIT_TEST_KNOCK_CRYPTO)
 
-$(UNIT_TEST_KNOCK_USER): tests/test_knock_user.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/xdp_loader.h | $(BUILD_DIR)
-	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_user.c src/user/cli_common.c -o $(UNIT_TEST_KNOCK_USER)
+$(UNIT_TEST_KNOCK_USER): tests/test_knock_user.c src/user/knock_user.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/xdp_loader.h | $(BUILD_DIR)
+	$(USER_CC) $(TEST_CFLAGS) $(USER_CPPFLAGS) -Iinclude -Isrc/user tests/test_knock_user.c src/user/cli_common.c -o $(UNIT_TEST_KNOCK_USER)
 
-$(UNIT_TEST_KNOCK_CLIENT): tests/test_knock_client.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/net_checksum.h | $(BUILD_DIR)
+$(UNIT_TEST_KNOCK_CLIENT): tests/test_knock_client.c src/user/knock_client.c src/user/cli_common.c include/shared.h include/knock_crypto.h src/user/cli_common.h src/user/net_checksum.h | $(BUILD_DIR)
 	$(USER_CC) $(TEST_CFLAGS) -Iinclude -Isrc/user tests/test_knock_client.c src/user/cli_common.c -o $(UNIT_TEST_KNOCK_CLIENT)
 
 run: all

--- a/include/knock_crypto.h
+++ b/include/knock_crypto.h
@@ -106,7 +106,7 @@ static __inline void knock_sha256_init(__u32 state[8])
     state[7] = 0x5be0cd19U;
 }
 
-static __inline void knock_sha256_transform(__u32 state[8], const __u8 block[64])
+static __inline void knock_sha256_transform_words(__u32 state[8], __u32 w[16])
 {
     __u32 a = state[0];
     __u32 b = state[1];
@@ -116,12 +116,7 @@ static __inline void knock_sha256_transform(__u32 state[8], const __u8 block[64]
     __u32 f = state[5];
     __u32 g = state[6];
     __u32 h = state[7];
-    __u32 w[16];
     __u32 i;
-
-    for (i = 0; i < 16; i++) {
-        w[i] = knock_load_be32(&block[i * 4]);
-    }
 
     for (i = 0; i < 64; i++) {
         __u32 s0;
@@ -166,8 +161,10 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
 {
     __u32 state[8];
     __u32 inner_digest[8];
-    __u8 block[64] = {};
+    __u32 w[16] = {};
     __u64 padded_len_bits = (64ULL + 32ULL) * 8ULL;
+    __u32 ipad_word = 0x36363636U;
+    __u32 opad_word = 0x5c5c5c5cU;
     __u32 i;
     __u64 m0 = ((__u64)in->timestamp_sec << 32) | (__u64)in->nonce;
     __u64 m1 = ((__u64)KNOCK_MAGIC << 32) |
@@ -180,53 +177,68 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     __u64 m3 = ((__u64)(in->bind_dst_port & 0x00ffU) << 56) |
                0x0053474e31ULL;
 
-    for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
-        block[i] = key[i];
+    for (i = 0; i < 8; i++) {
+        __u32 kword = ((__u32)key[i * 4] << 24) |
+                      ((__u32)key[i * 4 + 1] << 16) |
+                      ((__u32)key[i * 4 + 2] << 8) |
+                      (__u32)key[i * 4 + 3];
+        w[i] = kword ^ ipad_word;
     }
-    for (i = 0; i < 64; i++) {
-        block[i] ^= 0x36U;
+    for (i = 8; i < 16; i++) {
+        w[i] = ipad_word;
     }
 
     knock_sha256_init(state);
-    knock_sha256_transform(state, block);
+    knock_sha256_transform_words(state, w);
 
-    for (i = 0; i < 64; i++) {
-        block[i] = 0;
-    }
-    knock_store_be64(&block[0], m0);
-    knock_store_be64(&block[8], m1);
-    knock_store_be64(&block[16], m2);
-    knock_store_be64(&block[24], m3);
-    block[32] = 0x80U;
-    knock_store_be64(&block[56], padded_len_bits);
-    knock_sha256_transform(state, block);
+    w[0] = (__u32)(m0 >> 32);
+    w[1] = (__u32)m0;
+    w[2] = (__u32)(m1 >> 32);
+    w[3] = (__u32)m1;
+    w[4] = (__u32)(m2 >> 32);
+    w[5] = (__u32)m2;
+    w[6] = (__u32)(m3 >> 32);
+    w[7] = (__u32)m3;
+    w[8] = 0x80000000U;
+    w[9] = 0;
+    w[10] = 0;
+    w[11] = 0;
+    w[12] = 0;
+    w[13] = 0;
+    w[14] = (__u32)(padded_len_bits >> 32);
+    w[15] = (__u32)padded_len_bits;
+    knock_sha256_transform_words(state, w);
 
     for (i = 0; i < 8; i++) {
         inner_digest[i] = state[i];
     }
 
-    for (i = 0; i < 64; i++) {
-        block[i] = 0;
+    for (i = 0; i < 8; i++) {
+        __u32 kword = ((__u32)key[i * 4] << 24) |
+                      ((__u32)key[i * 4 + 1] << 16) |
+                      ((__u32)key[i * 4 + 2] << 8) |
+                      (__u32)key[i * 4 + 3];
+        w[i] = kword ^ opad_word;
     }
-    for (i = 0; i < KNOCK_HMAC_KEY_LEN; i++) {
-        block[i] = key[i];
-    }
-    for (i = 0; i < 64; i++) {
-        block[i] ^= 0x5cU;
+    for (i = 8; i < 16; i++) {
+        w[i] = opad_word;
     }
 
     knock_sha256_init(state);
-    knock_sha256_transform(state, block);
+    knock_sha256_transform_words(state, w);
 
-    for (i = 0; i < 64; i++) {
-        block[i] = 0;
-    }
     for (i = 0; i < 8; i++) {
-        knock_store_be32(&block[i * 4], inner_digest[i]);
+        w[i] = inner_digest[i];
     }
-    block[32] = 0x80U;
-    knock_store_be64(&block[56], padded_len_bits);
-    knock_sha256_transform(state, block);
+    w[8] = 0x80000000U;
+    w[9] = 0;
+    w[10] = 0;
+    w[11] = 0;
+    w[12] = 0;
+    w[13] = 0;
+    w[14] = (__u32)(padded_len_bits >> 32);
+    w[15] = (__u32)padded_len_bits;
+    knock_sha256_transform_words(state, w);
 
     out[0] = state[0];
     out[1] = state[1];

--- a/include/knock_crypto.h
+++ b/include/knock_crypto.h
@@ -14,6 +14,12 @@ struct knock_sig_input {
     __u16 bind_dst_port;
 };
 
+struct knock_sig_scratch {
+    __u32 state[8];
+    __u32 inner_digest[8];
+    __u32 w[16];
+};
+
 static const __u32 knock_sha256_k[64] = {
     0x428a2f98U, 0x71374491U, 0xb5c0fbcfU, 0xe9b5dba5U,
     0x3956c25bU, 0x59f111f1U, 0x923f82a4U, 0xab1c5ed5U,
@@ -106,7 +112,7 @@ static __inline void knock_sha256_init(__u32 state[8])
     state[7] = 0x5be0cd19U;
 }
 
-static __inline void knock_sha256_transform_words(__u32 state[8], __u32 w[16])
+static __attribute__((always_inline)) __inline void knock_sha256_transform_words(__u32 state[8], __u32 w[16])
 {
     __u32 a = state[0];
     __u32 b = state[1];
@@ -155,58 +161,51 @@ static __inline void knock_sha256_transform_words(__u32 state[8], __u32 w[16])
     state[7] += h;
 }
 
-static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
-                                           const struct knock_sig_input *in,
-                                           __u32 out[KNOCK_SIGNATURE_WORDS])
+static __inline void knock_signature_words_scratch(const __u8 key[KNOCK_HMAC_KEY_LEN],
+                                                   const struct knock_sig_input *in,
+                                                   __u32 out[KNOCK_SIGNATURE_WORDS],
+                                                   struct knock_sig_scratch *scratch)
 {
-    __u32 state[8];
-    __u32 inner_digest[8];
-    __u32 w[16] = {};
-    __u64 padded_len_bits = (64ULL + 32ULL) * 8ULL;
-    __u32 ipad_word = 0x36363636U;
-    __u32 opad_word = 0x5c5c5c5cU;
+    __u32 *state = scratch->state;
+    __u32 *inner_digest = scratch->inner_digest;
+    __u32 *w = scratch->w;
+    __u32 final_len_bits = (64U + 32U) * 8U;
     __u32 i;
-    __u64 m0 = ((__u64)in->timestamp_sec << 32) | (__u64)in->nonce;
-    __u64 m1 = ((__u64)KNOCK_MAGIC << 32) |
-               ((__u64)in->packet_type << 24) |
-               ((in->session_id_hi >> 8) & 0x00ffffffU);
-    __u64 m2 = ((__u64)(in->session_id_hi & 0x000000ffU) << 56) |
-               ((__u64)in->session_id_lo << 24) |
-               ((__u64)in->bind_src_port << 8) |
-               (__u64)(in->bind_dst_port >> 8);
-    __u64 m3 = ((__u64)(in->bind_dst_port & 0x00ffU) << 56) |
-               0x0053474e31ULL;
+
+    for (i = 0; i < 16; i++) {
+        w[i] = 0;
+    }
 
     for (i = 0; i < 8; i++) {
         __u32 kword = ((__u32)key[i * 4] << 24) |
                       ((__u32)key[i * 4 + 1] << 16) |
                       ((__u32)key[i * 4 + 2] << 8) |
                       (__u32)key[i * 4 + 3];
-        w[i] = kword ^ ipad_word;
+        w[i] = kword ^ 0x36363636U;
     }
     for (i = 8; i < 16; i++) {
-        w[i] = ipad_word;
+        w[i] = 0x36363636U;
     }
 
     knock_sha256_init(state);
     knock_sha256_transform_words(state, w);
 
-    w[0] = (__u32)(m0 >> 32);
-    w[1] = (__u32)m0;
-    w[2] = (__u32)(m1 >> 32);
-    w[3] = (__u32)m1;
-    w[4] = (__u32)(m2 >> 32);
-    w[5] = (__u32)m2;
-    w[6] = (__u32)(m3 >> 32);
-    w[7] = (__u32)m3;
+    w[0] = in->timestamp_sec;
+    w[1] = in->nonce;
+    w[2] = KNOCK_MAGIC;
+    w[3] = ((__u32)in->packet_type << 24) | ((in->session_id_hi >> 8) & 0x00ffffffU);
+    w[4] = ((in->session_id_hi & 0x000000ffU) << 24) | ((in->session_id_lo >> 8) & 0x00ffffffU);
+    w[5] = ((in->session_id_lo & 0x000000ffU) << 24) | ((__u32)in->bind_src_port << 8) | (in->bind_dst_port >> 8);
+    w[6] = (__u32)(in->bind_dst_port & 0x00ffU) << 24;
+    w[7] = 0x53474e31U;
     w[8] = 0x80000000U;
     w[9] = 0;
     w[10] = 0;
     w[11] = 0;
     w[12] = 0;
     w[13] = 0;
-    w[14] = (__u32)(padded_len_bits >> 32);
-    w[15] = (__u32)padded_len_bits;
+    w[14] = 0;
+    w[15] = final_len_bits;
     knock_sha256_transform_words(state, w);
 
     for (i = 0; i < 8; i++) {
@@ -218,10 +217,10 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
                       ((__u32)key[i * 4 + 1] << 16) |
                       ((__u32)key[i * 4 + 2] << 8) |
                       (__u32)key[i * 4 + 3];
-        w[i] = kword ^ opad_word;
+        w[i] = kword ^ 0x5c5c5c5cU;
     }
     for (i = 8; i < 16; i++) {
-        w[i] = opad_word;
+        w[i] = 0x5c5c5c5cU;
     }
 
     knock_sha256_init(state);
@@ -236,14 +235,23 @@ static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
     w[11] = 0;
     w[12] = 0;
     w[13] = 0;
-    w[14] = (__u32)(padded_len_bits >> 32);
-    w[15] = (__u32)padded_len_bits;
+    w[14] = 0;
+    w[15] = final_len_bits;
     knock_sha256_transform_words(state, w);
 
     out[0] = state[0];
     out[1] = state[1];
     out[2] = state[2];
     out[3] = state[3];
+}
+
+static __inline void knock_signature_words(const __u8 key[KNOCK_HMAC_KEY_LEN],
+                                           const struct knock_sig_input *in,
+                                           __u32 out[KNOCK_SIGNATURE_WORDS])
+{
+    struct knock_sig_scratch scratch;
+
+    knock_signature_words_scratch(key, in, out, &scratch);
 }
 
 #endif /* KNOCK_CRYPTO_H */

--- a/src/bpf/knock_kern.bpf.c
+++ b/src/bpf/knock_kern.bpf.c
@@ -77,6 +77,26 @@ struct {
     __type(value, struct debug_knock_snapshot);
 } debug_knock_map SEC(".maps");
 
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct knock_sig_scratch);
+} crypto_scratch_map SEC(".maps");
+
+struct knock_path_scratch {
+    struct knock_sig_input sig_in;
+    struct replay_nonce_key replay_key;
+    struct replay_nonce_state replay_state;
+};
+
+struct {
+    __uint(type, BPF_MAP_TYPE_PERCPU_ARRAY);
+    __uint(max_entries, 1);
+    __type(key, __u32);
+    __type(value, struct knock_path_scratch);
+} knock_path_scratch_map SEC(".maps");
+
 static __always_inline void bump(__u64 *counter)
 {
     if (counter) {
@@ -203,53 +223,25 @@ static __always_inline bool get_realtime_sec(__u32 *now_sec)
     return true;
 }
 
-static __always_inline bool knock_is_valid_with_key(const __u8 key[KNOCK_HMAC_KEY_LEN],
-                                                    const struct knock_packet *pkt)
+static __always_inline bool knock_signature_matches(const __u8 key[KNOCK_HMAC_KEY_LEN],
+                                                    const struct knock_sig_input *in,
+                                                    const __u32 pkt_sig[KNOCK_SIGNATURE_WORDS])
 {
-    __u32 now_sec;
-    __u32 ts_sec = bpf_ntohl(pkt->timestamp_sec);
-    __u32 nonce = bpf_ntohl(pkt->nonce);
-    __u8 packet_type = pkt->packet_type;
-    __u32 session_id_hi = bpf_ntohl(pkt->session_id_hi);
-    __u32 session_id_lo = bpf_ntohl(pkt->session_id_lo);
-    __u16 bind_src_port = bpf_ntohs(pkt->bind_src_port);
-    __u16 bind_dst_port = bpf_ntohs(pkt->bind_dst_port);
-    struct knock_sig_input in = {};
+    __u32 scratch_key = 0;
+    struct knock_sig_scratch *scratch;
     __u32 diff = 0;
     __u32 sig[KNOCK_SIGNATURE_WORDS];
     __u32 i;
 
-    if (pkt->magic != bpf_htonl(KNOCK_MAGIC)) {
+    scratch = bpf_map_lookup_elem(&crypto_scratch_map, &scratch_key);
+    if (!scratch) {
         return false;
     }
 
-    if (packet_type != KNOCK_PKT_AUTH && packet_type != KNOCK_PKT_DEAUTH && packet_type != KNOCK_PKT_BIND) {
-        return false;
-    }
-
-    if (!get_realtime_sec(&now_sec)) {
-        return false;
-    }
-
-    if (ts_sec + KNOCK_MAX_CLOCK_SKEW_SEC < now_sec) {
-        return false;
-    }
-    if (now_sec + KNOCK_MAX_CLOCK_SKEW_SEC < ts_sec) {
-        return false;
-    }
-
-    in.timestamp_sec = ts_sec;
-    in.packet_type = packet_type;
-    in.session_id_hi = session_id_hi;
-    in.session_id_lo = session_id_lo;
-    in.nonce = nonce;
-    in.bind_src_port = bind_src_port;
-    in.bind_dst_port = bind_dst_port;
-
-    knock_signature_words(key, &in, sig);
+    knock_signature_words_scratch(key, in, sig, scratch);
 #pragma clang loop unroll(full)
     for (i = 0; i < KNOCK_SIGNATURE_WORDS; i++) {
-        diff |= sig[i] ^ bpf_ntohl(pkt->signature[i]);
+        diff |= sig[i] ^ bpf_ntohl(pkt_sig[i]);
     }
 
     return diff == 0;
@@ -270,13 +262,7 @@ int port_knock_xdp(struct xdp_md *ctx)
     struct tcphdr *tcph;
     struct knock_packet *kpkt;
     struct active_session_state *sess;
-    struct pending_auth_state *pending;
-    struct pending_auth_state new_pending = {};
-    struct active_session_state new_sess = {};
-    struct session_lookup_key lookup_key = {};
-    struct session_lookup_key pending_key = {};
     struct flow_key flow = {};
-    struct flow_key *bound_flow;
     struct knock_config *cfg;
     __u16 dst_port;
     __u16 src_port;
@@ -336,19 +322,26 @@ int port_knock_xdp(struct xdp_md *ctx)
     flow.l4_proto = iph->protocol;
 
     if (dst_port == cfg->knock_port) {
+        __u32 scratch_key = 0;
+        struct knock_path_scratch *knock_scratch;
         __u32 nonce_host;
+        __u32 ts_sec;
+        __u32 now_sec;
         __u32 session_id_hi;
         __u32 session_id_lo;
         __u8 packet_type;
         __u16 bind_src_port;
         __u16 bind_dst_port;
         __u64 replay_window_ns;
-        struct replay_nonce_key replay_key = {};
-        struct replay_nonce_state replay_state = {};
-        struct session_lookup_key deauth_key = {};
         struct replay_nonce_state *seen;
 
         if (!source_pressure_allow_knock(iph->saddr, now_ns, stats)) {
+            return XDP_DROP;
+        }
+
+        knock_scratch = bpf_map_lookup_elem(&knock_path_scratch_map, &scratch_key);
+        if (!knock_scratch) {
+            bump(stats ? &stats->map_update_fail : NULL);
             return XDP_DROP;
         }
 
@@ -360,11 +353,41 @@ int port_knock_xdp(struct xdp_md *ctx)
         }
 
         nonce_host = bpf_ntohl(kpkt->nonce);
+        ts_sec = bpf_ntohl(kpkt->timestamp_sec);
         packet_type = kpkt->packet_type;
         session_id_hi = bpf_ntohl(kpkt->session_id_hi);
         session_id_lo = bpf_ntohl(kpkt->session_id_lo);
         bind_src_port = bpf_ntohs(kpkt->bind_src_port);
         bind_dst_port = bpf_ntohs(kpkt->bind_dst_port);
+
+        if (kpkt->magic != bpf_htonl(KNOCK_MAGIC)) {
+            bump(stats ? &stats->key_mismatch : NULL);
+            return XDP_DROP;
+        }
+
+        if (packet_type != KNOCK_PKT_AUTH && packet_type != KNOCK_PKT_DEAUTH && packet_type != KNOCK_PKT_BIND) {
+            bump(stats ? &stats->key_mismatch : NULL);
+            return XDP_DROP;
+        }
+
+        if (!get_realtime_sec(&now_sec)) {
+            bump(stats ? &stats->key_mismatch : NULL);
+            return XDP_DROP;
+        }
+
+        if (ts_sec + KNOCK_MAX_CLOCK_SKEW_SEC < now_sec ||
+            now_sec + KNOCK_MAX_CLOCK_SKEW_SEC < ts_sec) {
+            bump(stats ? &stats->key_mismatch : NULL);
+            return XDP_DROP;
+        }
+
+        knock_scratch->sig_in.timestamp_sec = ts_sec;
+        knock_scratch->sig_in.packet_type = packet_type;
+        knock_scratch->sig_in.session_id_hi = session_id_hi;
+        knock_scratch->sig_in.session_id_lo = session_id_lo;
+        knock_scratch->sig_in.nonce = nonce_host;
+        knock_scratch->sig_in.bind_src_port = bind_src_port;
+        knock_scratch->sig_in.bind_dst_port = bind_dst_port;
 
         if (snap) {
             snap->magic = kpkt->magic;
@@ -389,10 +412,10 @@ int port_knock_xdp(struct xdp_md *ctx)
                 return XDP_DROP;
             }
 
-            if (knock_is_valid_with_key(user_key->active_key, kpkt)) {
+            if (knock_signature_matches(user_key->active_key, &knock_scratch->sig_in, kpkt->signature)) {
                 valid = true;
             } else if (user_key->grace_until_ns >= now_ns &&
-                       knock_is_valid_with_key(user_key->previous_key, kpkt)) {
+                       knock_signature_matches(user_key->previous_key, &knock_scratch->sig_in, kpkt->signature)) {
                 bump(stats ? &stats->grace_key_used : NULL);
                 valid = true;
             } else {
@@ -403,38 +426,40 @@ int port_knock_xdp(struct xdp_md *ctx)
                 return XDP_DROP;
             }
 
-            pending_key.src_ip = iph->saddr;
-            pending_key.session_id_hi = session_id_hi;
-            pending_key.session_id_lo = session_id_lo;
+            knock_scratch->replay_key.src_ip = iph->saddr;
+            knock_scratch->replay_key.nonce = nonce_host;
+            knock_scratch->replay_key.packet_type = packet_type;
+            knock_scratch->replay_key.session_id_hi = session_id_hi;
+            knock_scratch->replay_key.session_id_lo = session_id_lo;
 
-            replay_key.src_ip = iph->saddr;
-            replay_key.nonce = nonce_host;
-            replay_key.packet_type = packet_type;
-            replay_key.session_id_hi = session_id_hi;
-            replay_key.session_id_lo = session_id_lo;
-
-            seen = bpf_map_lookup_elem(&replay_nonce_map, &replay_key);
+            seen = bpf_map_lookup_elem(&replay_nonce_map, &knock_scratch->replay_key);
             if (seen) {
                 if (seen->expires_at_ns >= now_ns) {
                     bump(stats ? &stats->replay_drop : NULL);
                     return XDP_DROP;
                 }
-                bpf_map_delete_elem(&replay_nonce_map, &replay_key);
+                bpf_map_delete_elem(&replay_nonce_map, &knock_scratch->replay_key);
             }
 
             replay_window_ns = (__u64)cfg->replay_window_ms * 1000000ULL;
             if (replay_window_ns < ((__u64)KNOCK_MAX_CLOCK_SKEW_SEC * 1000000000ULL)) {
                 replay_window_ns = (__u64)KNOCK_MAX_CLOCK_SKEW_SEC * 1000000000ULL;
             }
-            replay_state.expires_at_ns = now_ns + replay_window_ns;
+            knock_scratch->replay_state.expires_at_ns = now_ns + replay_window_ns;
             if (!update_map_or_fail(stats ? &stats->map_update_fail : NULL,
                                     &replay_nonce_map,
-                                    &replay_key,
-                                    &replay_state)) {
+                                    &knock_scratch->replay_key,
+                                    &knock_scratch->replay_state)) {
                 return XDP_DROP;
             }
 
             if (packet_type == KNOCK_PKT_AUTH) {
+                struct pending_auth_state new_pending = {};
+                struct session_lookup_key pending_key = {};
+
+                pending_key.src_ip = iph->saddr;
+                pending_key.session_id_hi = session_id_hi;
+                pending_key.session_id_lo = session_id_lo;
                 new_pending.session_id_hi = session_id_hi;
                 new_pending.session_id_lo = session_id_lo;
                 new_pending.expires_at_ns = now_ns + ((__u64)cfg->bind_window_ms * 1000000ULL);
@@ -446,6 +471,14 @@ int port_knock_xdp(struct xdp_md *ctx)
                 }
                 bump(stats ? &stats->knock_valid : NULL);
             } else if (packet_type == KNOCK_PKT_BIND) {
+                struct pending_auth_state *pending;
+                struct active_session_state new_sess = {};
+                struct session_lookup_key pending_key = {};
+                struct session_lookup_key lookup_key = {};
+
+                pending_key.src_ip = iph->saddr;
+                pending_key.session_id_hi = session_id_hi;
+                pending_key.session_id_lo = session_id_lo;
                 pending = bpf_map_lookup_elem(&pending_auth_map, &pending_key);
                 if (!pending) {
                     bump(stats ? &stats->bind_drop : NULL);
@@ -489,6 +522,9 @@ int port_knock_xdp(struct xdp_md *ctx)
                 bpf_map_delete_elem(&pending_auth_map, &pending_key);
                 bump(stats ? &stats->knock_valid : NULL);
             } else {
+                struct session_lookup_key deauth_key = {};
+                struct flow_key *bound_flow;
+
                 deauth_key.src_ip = iph->saddr;
                 deauth_key.session_id_hi = session_id_hi;
                 deauth_key.session_id_lo = session_id_lo;
@@ -518,6 +554,8 @@ int port_knock_xdp(struct xdp_md *ctx)
         return XDP_DROP;
     }
     if (sess->expires_at_ns < now_ns) {
+        struct session_lookup_key lookup_key = {};
+
         lookup_key.src_ip = iph->saddr;
         lookup_key.session_id_hi = sess->session_id_hi;
         lookup_key.session_id_lo = sess->session_id_lo;

--- a/tests/test_knock_client.c
+++ b/tests/test_knock_client.c
@@ -1,0 +1,135 @@
+#include <getopt.h>
+
+#include "net_checksum.h"
+#include "test_common.h"
+
+#define main knock_client_entry
+#include "../src/user/knock_client.c"
+#undef main
+
+uint16_t csum16(const void *data, size_t len)
+{
+    (void)data;
+    (void)len;
+    return 0;
+}
+
+uint16_t tcp_checksum(const struct iphdr *iph, const struct tcphdr *tcph, const void *payload, size_t payload_len)
+{
+    (void)iph;
+    (void)tcph;
+    (void)payload;
+    (void)payload_len;
+    return 0;
+}
+
+static void reset_getopt_state(void)
+{
+    optind = 1;
+    opterr = 0;
+}
+
+static int run_knock_client(int argc, char **argv)
+{
+    reset_getopt_state();
+    return knock_client_entry(argc, argv);
+}
+
+static void test_missing_required_arguments_returns_error(void)
+{
+    char *argv[] = {(char *)"knock-client", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(1, argv));
+}
+
+static void test_rejects_invalid_packet_type(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--packet-type",
+                    (char *)"invalid", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(11, argv));
+}
+
+static void test_rejects_invalid_dst_port(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--dst-port",
+                    (char *)"0", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(11, argv));
+}
+
+static void test_rejects_invalid_src_port(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--src-port",
+                    (char *)"70000", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(11, argv));
+}
+
+static void test_rejects_invalid_bind_port(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--bind-port",
+                    (char *)"0", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(11, argv));
+}
+
+static void test_rejects_invalid_hmac_key_length(void)
+{
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)"abcd", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(9, argv));
+}
+
+static void test_rejects_invalid_interface_name(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"no_such_iface", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(9, argv));
+}
+
+static void test_deauth_requires_session_id(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--packet-type",
+                    (char *)"deauth", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(11, argv));
+}
+
+static void test_bind_requires_bind_port(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knock-client", (char *)"--ifname", (char *)"lo", (char *)"--src-ip", (char *)"127.0.0.1",
+                    (char *)"--dst-ip", (char *)"127.0.0.1", (char *)"--hmac-key", (char *)key, (char *)"--packet-type",
+                    (char *)"bind", (char *)"--session-id", (char *)"123", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_client(13, argv));
+}
+
+int main(void)
+{
+    test_missing_required_arguments_returns_error();
+    test_rejects_invalid_packet_type();
+    test_rejects_invalid_dst_port();
+    test_rejects_invalid_src_port();
+    test_rejects_invalid_bind_port();
+    test_rejects_invalid_hmac_key_length();
+    test_rejects_invalid_interface_name();
+    test_deauth_requires_session_id();
+    test_bind_requires_bind_port();
+    puts("test_knock_client: ok");
+    return 0;
+}

--- a/tests/test_knock_crypto.c
+++ b/tests/test_knock_crypto.c
@@ -1,0 +1,102 @@
+#include "knock_crypto.h"
+#include "test_common.h"
+
+static void test_knock_signature_words_matches_known_vector(void)
+{
+    static const __u8 key[KNOCK_HMAC_KEY_LEN] = {
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+        0x00, 0x11, 0x22, 0x33, 0x44, 0x55, 0x66, 0x77,
+        0x88, 0x99, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff,
+    };
+    struct knock_sig_input in = {
+        .timestamp_sec = 1710000000U,
+        .packet_type = KNOCK_PKT_AUTH,
+        .session_id_hi = 0x00640012U,
+        .session_id_lo = 0x89abcdefU,
+        .nonce = 0x13572468U,
+        .bind_src_port = 50000U,
+        .bind_dst_port = 22U,
+    };
+    __u32 out[KNOCK_SIGNATURE_WORDS] = {0};
+
+    knock_signature_words(key, &in, out);
+
+    ASSERT_EQ_U32(0x314ff370U, out[0]);
+    ASSERT_EQ_U32(0x4b58cb8aU, out[1]);
+    ASSERT_EQ_U32(0xe8106c83U, out[2]);
+    ASSERT_EQ_U32(0x1d13b0a4U, out[3]);
+}
+
+static void test_knock_signature_words_changes_with_packet_type(void)
+{
+    static const __u8 key[KNOCK_HMAC_KEY_LEN] = {
+        0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe,
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+        0x10, 0x32, 0x54, 0x76, 0x98, 0xba, 0xdc, 0xfe,
+        0x01, 0x23, 0x45, 0x67, 0x89, 0xab, 0xcd, 0xef,
+    };
+    struct knock_sig_input auth = {
+        .timestamp_sec = 1710001234U,
+        .packet_type = KNOCK_PKT_AUTH,
+        .session_id_hi = 0x00010002U,
+        .session_id_lo = 0x00030004U,
+        .nonce = 0x11223344U,
+        .bind_src_port = 12345U,
+        .bind_dst_port = 443U,
+    };
+    struct knock_sig_input deauth = auth;
+    __u32 sig_auth[KNOCK_SIGNATURE_WORDS] = {0};
+    __u32 sig_deauth[KNOCK_SIGNATURE_WORDS] = {0};
+
+    deauth.packet_type = KNOCK_PKT_DEAUTH;
+
+    knock_signature_words(key, &auth, sig_auth);
+    knock_signature_words(key, &deauth, sig_deauth);
+
+    ASSERT_TRUE(sig_auth[0] != sig_deauth[0] ||
+                sig_auth[1] != sig_deauth[1] ||
+                sig_auth[2] != sig_deauth[2] ||
+                sig_auth[3] != sig_deauth[3]);
+}
+
+static void test_knock_signature_words_changes_with_bind_ports(void)
+{
+    static const __u8 key[KNOCK_HMAC_KEY_LEN] = {
+        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88,
+        0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+        0xff, 0xee, 0xdd, 0xcc, 0xbb, 0xaa, 0x99, 0x88,
+        0x77, 0x66, 0x55, 0x44, 0x33, 0x22, 0x11, 0x00,
+    };
+    struct knock_sig_input in_a = {
+        .timestamp_sec = 1710002222U,
+        .packet_type = KNOCK_PKT_BIND,
+        .session_id_hi = 0x00070008U,
+        .session_id_lo = 0x0009000aU,
+        .nonce = 0x55667788U,
+        .bind_src_port = 34567U,
+        .bind_dst_port = 8080U,
+    };
+    struct knock_sig_input in_b = in_a;
+    __u32 sig_a[KNOCK_SIGNATURE_WORDS] = {0};
+    __u32 sig_b[KNOCK_SIGNATURE_WORDS] = {0};
+
+    in_b.bind_dst_port = 8443U;
+
+    knock_signature_words(key, &in_a, sig_a);
+    knock_signature_words(key, &in_b, sig_b);
+
+    ASSERT_TRUE(sig_a[0] != sig_b[0] ||
+                sig_a[1] != sig_b[1] ||
+                sig_a[2] != sig_b[2] ||
+                sig_a[3] != sig_b[3]);
+}
+
+int main(void)
+{
+    test_knock_signature_words_matches_known_vector();
+    test_knock_signature_words_changes_with_packet_type();
+    test_knock_signature_words_changes_with_bind_ports();
+    puts("test_knock_crypto: ok");
+    return 0;
+}

--- a/tests/test_knock_user.c
+++ b/tests/test_knock_user.c
@@ -1,0 +1,238 @@
+#include <errno.h>
+#include <getopt.h>
+#include <string.h>
+
+#include "shared.h"
+#include "test_common.h"
+#include "xdp_loader.h"
+
+#define main knock_user_entry
+#include "../src/user/knock_user.c"
+#undef main
+
+static int stub_validate_config_rc = 0;
+static int stub_attach_rc = -1;
+static int stub_attach_called = 0;
+static __u32 stub_attach_user_count = 0;
+static struct knock_user_record stub_attach_users[KNOCK_MAX_USERS];
+
+int bpf_obj_get(const char *path)
+{
+    (void)path;
+    errno = ENOENT;
+    return -1;
+}
+
+int bpf_map_lookup_elem(int fd, const void *key, void *value)
+{
+    (void)fd;
+    (void)key;
+    (void)value;
+    errno = ENOENT;
+    return -1;
+}
+
+int bpf_map_update_elem(int fd, const void *key, const void *value, __u64 flags)
+{
+    (void)fd;
+    (void)key;
+    (void)value;
+    (void)flags;
+    errno = EPERM;
+    return -1;
+}
+
+int bpf_map_delete_elem(int fd, const void *key)
+{
+    (void)fd;
+    (void)key;
+    errno = ENOENT;
+    return -1;
+}
+
+int bpf_map_get_next_key(int fd, const void *key, void *next_key)
+{
+    (void)fd;
+    (void)key;
+    (void)next_key;
+    errno = ENOENT;
+    return -1;
+}
+
+int knock_loader_validate_config(const struct knock_config *cfg)
+{
+    (void)cfg;
+    return stub_validate_config_rc;
+}
+
+int knock_loader_attach(const struct knock_loader_opts *opts,
+                        const struct knock_config *cfg,
+                        const struct knock_user_record *users,
+                        __u32 user_count,
+                        struct knock_loader_handle *handle)
+{
+    (void)opts;
+    (void)cfg;
+    (void)handle;
+
+    stub_attach_called = 1;
+    stub_attach_user_count = user_count;
+    if (users && user_count > 0) {
+        memcpy(stub_attach_users, users, sizeof(struct knock_user_record) * user_count);
+    }
+
+    return stub_attach_rc;
+}
+
+void knock_loader_detach(struct knock_loader_handle *handle)
+{
+    (void)handle;
+}
+
+static void reset_test_state(void)
+{
+    optind = 1;
+    opterr = 0;
+    stub_validate_config_rc = 0;
+    stub_attach_rc = -1;
+    stub_attach_called = 0;
+    stub_attach_user_count = 0;
+    memset(stub_attach_users, 0, sizeof(stub_attach_users));
+}
+
+static int run_knock_user(int argc, char **argv)
+{
+    reset_test_state();
+    return knock_user_entry(argc, argv);
+}
+
+static void test_unknown_subcommand_returns_error(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"unknown", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(2, argv));
+}
+
+static void test_daemon_requires_ifname_and_protect(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"daemon", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(2, argv));
+}
+
+static void test_daemon_rejects_invalid_knock_port(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22", (char *)"--hmac-key", (char *)key, (char *)"--knock-port", (char *)"0", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(10, argv));
+}
+
+static void test_daemon_rejects_invalid_duration(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22", (char *)"--hmac-key", (char *)key, (char *)"--duration-sec", (char *)"0", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(10, argv));
+}
+
+static void test_daemon_rejects_invalid_hmac_key(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22", (char *)"--hmac-key", (char *)"1234", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(8, argv));
+}
+
+static void test_daemon_requires_users_file_or_hmac_key(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(6, argv));
+}
+
+static void test_daemon_returns_loader_validate_failure(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22", (char *)"--hmac-key", (char *)key, NULL};
+
+    reset_test_state();
+    stub_validate_config_rc = -1;
+    ASSERT_EQ_INT(1, knock_user_entry(8, argv));
+}
+
+static void test_daemon_uses_fallback_user_when_hmac_is_provided(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"daemon", (char *)"--ifname", (char *)"lo", (char *)"--protect",
+                    (char *)"22,443", (char *)"--hmac-key", (char *)key, NULL};
+
+    reset_test_state();
+    stub_attach_rc = -1;
+    ASSERT_EQ_INT(1, knock_user_entry(8, argv));
+    ASSERT_TRUE(stub_attach_called == 1);
+    ASSERT_EQ_U32(1, stub_attach_user_count);
+    ASSERT_EQ_U32(0, stub_attach_users[0].user_id);
+}
+
+static void test_register_user_requires_fields(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"register-user", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(2, argv));
+}
+
+static void test_register_user_with_missing_map_returns_error(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"register-user", (char *)"--user-id", (char *)"42", (char *)"--hmac-key",
+                    (char *)key, NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(6, argv));
+}
+
+static void test_rotate_user_rejects_invalid_user_id(void)
+{
+    static const char key[] = "00112233445566778899aabbccddeeff00112233445566778899aabbccddeeff";
+    char *argv[] = {(char *)"knockd", (char *)"rotate-user-key", (char *)"--user-id", (char *)"70000", (char *)"--hmac-key",
+                    (char *)key, NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(6, argv));
+}
+
+static void test_revoke_user_requires_user_id(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"revoke-user", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(2, argv));
+}
+
+static void test_list_users_with_missing_map_returns_error(void)
+{
+    char *argv[] = {(char *)"knockd", (char *)"list-users", NULL};
+
+    ASSERT_EQ_INT(1, run_knock_user(2, argv));
+}
+
+int main(void)
+{
+    test_unknown_subcommand_returns_error();
+    test_daemon_requires_ifname_and_protect();
+    test_daemon_rejects_invalid_knock_port();
+    test_daemon_rejects_invalid_duration();
+    test_daemon_rejects_invalid_hmac_key();
+    test_daemon_requires_users_file_or_hmac_key();
+    test_daemon_returns_loader_validate_failure();
+    test_daemon_uses_fallback_user_when_hmac_is_provided();
+    test_register_user_requires_fields();
+    test_register_user_with_missing_map_returns_error();
+    test_rotate_user_rejects_invalid_user_id();
+    test_revoke_user_requires_user_id();
+    test_list_users_with_missing_map_returns_error();
+    puts("test_knock_user: ok");
+    return 0;
+}


### PR DESCRIPTION
## Summary
- add unit tests for the shared HMAC-SHA256 signature primitive with deterministic vectors and mutation checks
- add unit tests for knock daemon CLI/subcommand validation paths using lightweight stubs for loader/map dependencies
- add unit tests for knock client argument validation and packet-mode constraints
- wire new test binaries into  so ./build/test_cli_common
test_cli_common: ok
./build/test_net_checksum
test_net_checksum: ok
./build/test_knock_crypto
test_knock_crypto: ok
./build/test_knock_user
test_knock_user: ok
./build/test_knock_client
test_knock_client: ok exercises the expanded suite

## Validation
- make unit-test

## Scope
- no admin-panel changes
- focuses on non-root, deterministic userspace coverage gains
